### PR TITLE
docs: update README and fix PORT_ALLOCATION

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,29 @@
 # infra
-Server configuration for `victorpatrin.dev`, reverse proxy routing, and static assets for victorpatrin.dev 
+
+Server configuration for `victorpatrin.dev` — reverse proxy routing, TLS termination, and static assets.
 
 ## What's in here
 
 - **Caddyfile** — reverse proxy routing + TLS termination for all subdomains
 - **docker-compose.yml** — Caddy container
 - **homepage/** — static site served on `victorpatrin.dev`
+- **wine-placeholder/** — placeholder SPA for `wine.victorpatrin.dev`
+- **scripts/** — repo setup automation (`setup-repo.sh`)
+- **docs/** — port allocation and network layout documentation
+- **.github/** — PR template
+
+## Routing
+
+| Domain | Target |
+|--------|--------|
+| `victorpatrin.dev` | Static homepage |
+| `s.victorpatrin.dev` | url-shortener API |
+| `analytics.victorpatrin.dev` | Umami |
+| `status.victorpatrin.dev` | Uptime Kuma |
+| `wine.victorpatrin.dev` | SAQ Sommelier (API + SPA) |
 
 ## Deployment
+
 ```bash
 ssh web-01
 cd ~/infra
@@ -15,9 +31,8 @@ git pull
 docker compose up -d --build
 ```
 
-## Routing
+For Caddyfile-only changes (no downtime):
 
-| Domain | Target |
-|--------|--------|
-| `victorpatrin.dev` | Static homepage |
-| `s.victorpatrin.dev` | url-shortener |
+```bash
+make reload
+```

--- a/docs/PORT_ALLOCATION.md
+++ b/docs/PORT_ALLOCATION.md
@@ -6,7 +6,7 @@ Network layout for all services on the VPS. Caddy is the only public entry point
 
 | Service | Container name | Internal port | Subdomain | Project |
 |---------|---------------|---------------|-----------|---------|
-| Caddy | infra-caddy-1 | 80, 443 | *.victorpatrin.dev (routing) | infra |
+| Caddy | caddy | 80, 443 | *.victorpatrin.dev (routing) | infra |
 | PostgreSQL | shared-postgres | 5432 | — | shared-postgres |
 | Umami | umami | 3000 | `analytics.victorpatrin.dev` | umami |
 | Uptime Kuma | uptime-kuma | 3001 | `status.victorpatrin.dev` | uptime-kuma |


### PR DESCRIPTION
## Summary
- Complete the README routing table (was missing 3 of 5 routes) and directory listing
- Fix wrong Caddy container name in PORT_ALLOCATION.md (`infra-caddy-1` → `caddy`)
- Document `make reload` for no-downtime Caddyfile deploys

## Related issue(s)
Closes #10