### PR TITLE
chore: harden docker-compose with healthcheck, log rotation, and security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   caddy:
-    image: caddy:2
+    image: caddy:2.9
     container_name: caddy
     restart: unless-stopped
     ports:
@@ -14,6 +14,20 @@ services:
       - caddy_config:/config
     networks:
       - internal
+    healthcheck:
+      test: ["CMD", "caddy", "validate", "--config", "/etc/caddy/Caddyfile"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 256m
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   caddy_data:

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -92,6 +92,13 @@ Everything else. All service containers can be rebuilt from their repos. Static 
 - systemd timer at 3:00 AM.
 - ~150MB disk budget (50MB DB × ~5MB compressed × 30 days).
 
+## Logging
+
+Docker container logs are stored at `/var/lib/docker/containers/<id>/<id>-json.log`. Each service has log rotation configured in its `docker-compose.yml` (10MB max per file, 3 files retained = 30MB cap per service).
+
+- **View logs**: `make logs` or `docker logs caddy`
+- **Raw access**: useful if Docker daemon or container is down
+
 ## Monitoring
 
 | Tool | URL | Purpose |


### PR DESCRIPTION
## Summary

- Pin Caddy image to `2.9` (minor version pin, patch updates only)
- Add healthcheck using `caddy validate`
- Add `no-new-privileges` security option
- Add `mem_limit: 256m` hard cap
- Add log rotation (10MB x 3 files = 30MB cap)
- Document logging in INFRASTRUCTURE.md

## How to test

```bash
docker compose config   # validate syntax
make restart            # apply changes (requires container restart)
docker inspect caddy | jq '.[0].HostConfig.SecurityOpt'
```

Closes #8