### PR TITLE
chore: add automated weekly pg_dump backups with 30-day retention

### DIFF
--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Backup individual PostgreSQL databases from the shared-postgres container.
+# Usage:
+#   ./backup.sh              # Dump all databases
+#   ./backup.sh saq_sommelier # Dump a single database (used by deploy scripts)
+
+BACKUP_DIR="/var/backups/postgres"
+CONTAINER="shared-postgres"
+PG_USER="postgres"
+RETENTION_DAYS=30
+DATE=$(date +%Y%m%d)
+
+DATABASES=("saq_sommelier" "umami" "url_shortener")
+
+# If a specific database is requested, only dump that one
+if [[ $# -ge 1 ]]; then
+    DATABASES=("$1")
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+for db in "${DATABASES[@]}"; do
+    file="${BACKUP_DIR}/${db}_${DATE}.sql.gz"
+    echo "Backing up ${db}..."
+    docker exec "$CONTAINER" pg_dump -U "$PG_USER" "$db" | gzip > "${file}.tmp"
+    mv "${file}.tmp" "$file"
+    echo "  -> ${file} ($(du -h "$file" | cut -f1))"
+done
+
+# Clean up backups older than retention period
+echo "Cleaning up backups older than ${RETENTION_DAYS} days..."
+find "$BACKUP_DIR" -name "*.sql.gz" -mtime +"$RETENTION_DAYS" -delete
+
+echo "Done."

--- a/backup/pg-backup.service
+++ b/backup/pg-backup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=PostgreSQL database backup
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStartPre=+/usr/bin/mkdir -p /var/backups/postgres
+ExecStartPre=+/usr/bin/chown victor:victor /var/backups/postgres
+ExecStart=/home/victor/infra/backup/backup.sh
+User=victor

--- a/backup/pg-backup.timer
+++ b/backup/pg-backup.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Weekly PostgreSQL backup (Monday 02:00, before scraper at 03:00)
+
+[Timer]
+OnCalendar=Mon *-*-* 02:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -72,7 +72,7 @@ Applied to all sites via a shared Caddyfile snippet ([#12](https://github.com/vp
 
 ## Backups
 
-**Status: not yet automated** (tracked in [#6](https://github.com/vpatrin/infra/issues/6)).
+Weekly automated backups via systemd timer ([#6](https://github.com/vpatrin/infra/issues/6)).
 
 ### What's stateful
 
@@ -86,11 +86,27 @@ Applied to all sites via a shared Caddyfile snippet ([#12](https://github.com/vp
 
 Everything else. All service containers can be rebuilt from their repos. Static sites are in git.
 
-### Planned strategy
+### Strategy
 
-- Daily `pg_dump` of all databases (compressed), retained for 30 days.
-- systemd timer at 3:00 AM.
-- ~150MB disk budget (50MB DB × ~5MB compressed × 30 days).
+- Weekly `pg_dump` per database (compressed), retained for 30 days
+- systemd timer: Monday 02:00 (before scraper at 03:00)
+- Pre-deploy dumps via `./backup/backup.sh <db_name>` (called by deploy scripts)
+- Storage: `/var/backups/postgres/` (~2MB per dump × 3 DBs × 4 weeks = ~24MB)
+
+### Setup on VPS
+
+```bash
+sudo cp backup/pg-backup.service backup/pg-backup.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now pg-backup.timer
+```
+
+### Manual backup
+
+```bash
+./backup/backup.sh                  # all databases
+./backup/backup.sh saq_sommelier    # single database
+```
 
 ## Logging
 


### PR DESCRIPTION
## Summary

- Add `backup/backup.sh` — per-database `pg_dump` via `docker exec`, compressed, 30-day retention
- Add systemd timer + service for weekly backups (Monday 02:00, before scraper at 03:00)
- Supports single-DB mode for pre-deploy backups (`./backup.sh saq_sommelier`)
- Update INFRASTRUCTURE.md with backup strategy and setup instructions

## Changes

- `backup/backup.sh` — backup script (atomic writes, retention cleanup)
- `backup/pg-backup.service` — systemd oneshot service
- `backup/pg-backup.timer` — weekly timer with `Persistent=true`
- `docs/INFRASTRUCTURE.md` — updated backup section from "planned" to actual

## How to test

```bash
# On VPS after deploy:
./backup/backup.sh                  # manual run, all DBs
ls -lh /var/backups/postgres/       # verify dumps created
systemctl status pg-backup.timer    # verify timer active
```

Closes #6