### PR TITLE
feat: serve coupette.club with path-based routing

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -15,18 +15,18 @@ victorpatrin.dev {
 	file_server
 }
 
-wine.victorpatrin.dev {
+coupette.club {
 	import security_headers
 	encode zstd gzip
-	# Any request starting with /api/ gets proxied to the saq-backend 
-	handle /api/* { 
+	# API requests proxied to backend container
+	handle /api/* {
 		reverse_proxy saq-backend:8001
 	}
-	# handle (catch-all) — Everything else serves the React SPA from /srv/wine
+	# Everything else serves the static SPA
 	handle {
-		root * /srv/wine
+		root * /srv/coupette
 		file_server
-		try_files {path} /index.html # if the requested file doesn't exist on disk, it falls back to index.html
+		try_files {path} /index.html
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Server configuration for `victorpatrin.dev` — reverse proxy routing, TLS termi
 - **Caddyfile** — reverse proxy routing + TLS termination for all subdomains
 - **docker-compose.yml** — Caddy container
 - **homepage/** — static site served on `victorpatrin.dev`
-- **`/srv/wine`** (host path) — static SPA for `wine.victorpatrin.dev`
+- **`/srv/coupette`** (host path) — static SPA for `coupette.club`
 - **scripts/** — repo setup automation (`setup-repo.sh`)
 - **docs/** — port allocation and network layout documentation
 - **.github/** — PR template
@@ -20,7 +20,7 @@ Server configuration for `victorpatrin.dev` — reverse proxy routing, TLS termi
 | `s.victorpatrin.dev` | url-shortener API |
 | `analytics.victorpatrin.dev` | Umami |
 | `status.victorpatrin.dev` | Uptime Kuma |
-| `wine.victorpatrin.dev` | SAQ Sommelier (API + SPA) |
+| `coupette.club` | Coupette (API + SPA) |
 
 ## Deployment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
       # Homepage files (Portfolio)
       - ./homepage:/srv/homepage
-      # saq-sommelier dist files
-      - /srv/wine:/srv/wine
+      # coupette.club frontend dist files
+      - /srv/coupette:/srv/coupette
       - caddy_data:/data
       - caddy_config:/config
     networks:

--- a/docs/PORT_ALLOCATION.md
+++ b/docs/PORT_ALLOCATION.md
@@ -6,16 +6,16 @@ Network layout for all services on the VPS. Caddy is the only public entry point
 
 | Service | Container name | Internal port | Subdomain | Project |
 |---------|---------------|---------------|-----------|---------|
-| Caddy | caddy | 80, 443 | *.victorpatrin.dev (routing) | infra |
+| Caddy | caddy | 80, 443 | *.victorpatrin.dev + coupette.club (routing) | infra |
 | PostgreSQL | shared-postgres | 5432 | — | shared-postgres |
 | Umami | umami | 3000 | `analytics.victorpatrin.dev` | umami |
 | Uptime Kuma | uptime-kuma | 3001 | `status.victorpatrin.dev` | uptime-kuma |
 | URL shortener API | url-shortener-api | 8000 | `s.victorpatrin.dev` | url-shortener |
 | Redis | url-shortener-redis-1 | 6379 | — | url-shortener |
-| SAQ backend | saq-backend | 8001 | `wine.victorpatrin.dev/api` | saq-sommelier |
-| SAQ bot | saq-sommelier-bot-1 | — | — | saq-sommelier |
-| SAQ scraper | saq-sommelier-scraper-1 | — | — (one-shot cron) | saq-sommelier |
-| React (static) | — | — | `wine.victorpatrin.dev` (served by Caddy) | saq-sommelier |
+| Coupette backend | saq-backend | 8001 | `coupette.club/api` | coupette |
+| Coupette bot | saq-sommelier-bot-1 | — | — | coupette |
+| Coupette scraper | saq-sommelier-scraper-1 | — | — (one-shot cron) | coupette |
+| Coupette frontend (static) | — | — | `coupette.club` (served by Caddy) | coupette |
 
 ## Host-exposed ports
 


### PR DESCRIPTION
## Summary
- Replace `wine.victorpatrin.dev` with `coupette.club` in Caddy routing
- Serve static SPA from `/srv/coupette` (host path) instead of `/srv/wine`
- Remove all SAQ/saq-sommelier references from docs

## Changes
- **Caddyfile**: `wine.victorpatrin.dev` → `coupette.club`, `/srv/wine` → `/srv/coupette`
- **docker-compose.yml**: Volume mount updated to `/srv/coupette:/srv/coupette`
- **README.md**: Routing table and "What's in here" updated
- **docs/PORT_ALLOCATION.md**: All SAQ/saq-sommelier refs → coupette

## Pre-requisites
- DNS: `A coupette.club → 46.225.60.166` (done)
- VPS: `mkdir -p /srv/coupette && chown victor:victor /srv/coupette`

## Deploy steps
1. `mv /srv/wine/* /srv/coupette/`
2. `git pull && docker compose up -d caddy`
3. Verify: `curl -I https://coupette.club`

Relates to vpatrin/saq-sommelier#403