### PR TITLE
fix: add DAC_OVERRIDE cap for uptime-kuma startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,9 @@ services:
     networks:
       - internal
     security_opt: [no-new-privileges:true]
+    # setpriv needs these caps to switch user/group at startup.
     cap_drop: [ALL]
+    cap_add: [CHOWN, SETUID, SETGID, DAC_OVERRIDE]
     mem_limit: 256m
     logging:
       driver: json-file


### PR DESCRIPTION
## Summary

- Uptime Kuma crash-loops with `cap_drop: [ALL]` — `setpriv` needs `DAC_OVERRIDE` to switch user/group at startup
- Adds `cap_add: [CHOWN, SETUID, SETGID, DAC_OVERRIDE]` to uptime-kuma service

## Changes

| File | Why |
|---|---|
| `docker-compose.yml` | Add `cap_add` with minimal caps for uptime-kuma's `setpriv` entrypoint |

## Deploy notes

```bash
git pull
docker compose up -d uptime-kuma
docker logs uptime-kuma --tail 10   # Verify no more setgroups errors
```