### PR TITLE
fix: deploy workflow cleanup and sops output format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,6 @@ jobs:
           username: ${{ secrets.SSH_DEPLOY_USER }}
           key: ${{ secrets.SSH_DEPLOY_KEY }}
           envs: SOPS_AGE_KEY
-          script: |
-            git -C ~/infra config --list | grep -i url
-            whoami
-            echo "HOME=$HOME"
-            git -C ~/infra remote -v
-            SOPS_AGE_KEY='${{ secrets.SOPS_AGE_KEY }}' ~/infra/scripts/deploy_infra.sh
+          script: ~/infra/scripts/deploy_infra.sh
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}

--- a/scripts/deploy_infra.sh
+++ b/scripts/deploy_infra.sh
@@ -25,7 +25,7 @@ echo "==> Decrypting secrets..."
     for svc in "${ENCRYPTED_SERVICES[@]}"; do
         enc="${INFRA_DIR}/services/${svc}/.env.prod.enc"
         [[ -f "${enc}" ]] || { echo "ERROR: ${enc} not found"; exit 1; }
-        sops --decrypt "${enc}" > "${INFRA_DIR}/services/${svc}/.env.prod"
+        sops --decrypt --output-type dotenv "${enc}" > "${INFRA_DIR}/services/${svc}/.env.prod"
     done
 )
 


### PR DESCRIPTION
## Summary
- Remove debug lines from deploy workflow, restore clean script invocation
- Fix sops decryption to output dotenv format (encrypted files are JSON, compose needs dotenv)

## Changes
- `.github/workflows/deploy.yml` — revert to single `script:` line, remove debug commands
- `scripts/deploy_infra.sh` — add `--output-type dotenv` to `sops --decrypt`

## Deploy notes
- VPS remote must be set to HTTPS: `git -C ~/infra remote set-url origin https://github.com/vpatrin/infra.git`
- `SSH_DEPLOY_USER` secret must point to the correct deploy user