### PR TITLE
fix: remove env_file from base compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:5432:5432"  # Localhost only — for DBeaver, Alembic
-    env_file: ./services/postgres/.env
     shm_size: 256mb
     volumes:
       - shared-postgres_pgdata:/var/lib/postgresql/data
@@ -68,7 +67,6 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"  # Localhost only — Caddy proxies public traffic
-    env_file: ./services/umami/.env
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Remove `env_file` from postgres and umami in base `docker-compose.yml`
- The prod overlay (`docker-compose.prod.yml`) already declares `env_file: .env.prod` for both services
- Compose validates all `env_file` paths from the base before merging overlays, causing deploy failures when `.env` doesn't exist on the VPS

## Changes
- `docker-compose.yml` — remove `env_file` from `postgres` and `umami` service definitions

## Deploy notes
None — the prod overlay already provides `env_file` and is unaffected by this change.