### PR TITLE
fix: bump umami to v3.0.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
         max-file: "3"
 
   umami:
-    image: ghcr.io/umami-software/umami:postgresql-v2.20.2
+    image: ghcr.io/umami-software/umami:postgresql-v3.0.3
     container_name: umami
     restart: unless-stopped
     ports:

--- a/services/caddy/Caddyfile
+++ b/services/caddy/Caddyfile
@@ -39,4 +39,3 @@ status.victorpatrin.dev {
 	import security_headers
 	reverse_proxy uptime-kuma:3001
 }
-


### PR DESCRIPTION
## Summary
- Bump Umami from `postgresql-v2.20.2` to `postgresql-v3.0.3`
- v2.20.2 has a Prisma schema engine binary missing, causing container startup failure

## Changes
- `docker-compose.yml` — update umami image tag
- `services/caddy/Caddyfile` — remove trailing blank line

## Deploy notes
Umami container will be recreated on next deploy. Check https://analytics.victorpatrin.dev after deploy.