### PR TITLE
fix: align deploy health checks with compose definitions

### DIFF
--- a/scripts/deploy_infra.sh
+++ b/scripts/deploy_infra.sh
@@ -93,19 +93,6 @@ check_health_inspect() {
     FAILED=1
 }
 
-check_health_cmd() {
-    local name="$1" cmd="$2" retries=5 delay=3
-    for _ in $(seq 1 "${retries}"); do
-        if eval "${cmd}" > /dev/null 2>&1; then
-            echo "  ✓ ${name}"
-            return 0
-        fi
-        sleep "${delay}"
-    done
-    echo "  ✗ ${name}"
-    FAILED=1
-}
-
 # Services with compose healthchecks — reuse via docker inspect
 check_health_inspect "postgres"   "shared-postgres"
 check_health_inspect "caddy"


### PR DESCRIPTION
## Summary

- Align deploy script health checks with compose health check changes from #85
- Move caddy and uptime-kuma to `check_health_inspect` (both now have compose health checks)
- Remove alloy from health checks (no health check defined in compose)
- Remove dead `check_health_cmd` function (no longer called)

## Changes

- `scripts/deploy_infra.sh` — update health check calls to match compose definitions

## Deploy notes

No action needed — this fix is for the deploy script itself.