### PR TITLE
fix: caddy and uptime-kuma health check endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     networks:
       - internal
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:80 -o /dev/null"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:2019/config/ -o /dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -90,7 +90,7 @@ services:
     networks:
       - internal
     healthcheck:
-      test: ["CMD-SHELL", "node -e 'fetch(\"http://localhost:3001/api/status-page/heartbeat\").then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))'"]
+      test: ["CMD-SHELL", "node -e 'fetch(\"http://localhost:3001\").then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))'"]
       interval: 15s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

- **Caddy**: use admin API (`localhost:2019/config/`) instead of port 80 which returns HTTP errors due to auto-HTTPS redirect
- **Uptime Kuma**: use root `/` instead of `/api/status-page/heartbeat` which returns 404

Both endpoints verified on VPS before committing.

## Changes

- `docker-compose.yml` — fix health check endpoints for caddy and uptime-kuma

## Deploy notes

Requires `make restart` — health check definitions changed.