### PR TITLE
fix: grafana dashboard provisioning mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,7 +208,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./services/grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./services/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - ./services/grafana/dashboards:/etc/grafana/dashboards:ro
     depends_on:
       loki:
         condition: service_healthy

--- a/services/grafana/provisioning/dashboards/dashboards.yaml
+++ b/services/grafana/provisioning/dashboards/dashboards.yaml
@@ -9,4 +9,4 @@ providers:
     updateIntervalSeconds: 30
     allowUiUpdates: false
     options:
-      path: /var/lib/grafana/dashboards
+      path: /etc/grafana/dashboards


### PR DESCRIPTION
## Summary

- Fix Grafana dashboards not loading due to bind mount conflict with named volume
- Named volume at `/var/lib/grafana` shadows the bind mount at `/var/lib/grafana/dashboards`, resulting in an empty directory inside the container
- Move dashboard mount to `/etc/grafana/dashboards` to avoid the conflict

## Changes

- `docker-compose.yml` — dashboard bind mount path changed to `/etc/grafana/dashboards:ro`
- `services/grafana/provisioning/dashboards/dashboards.yaml` — provisioning path updated to match

## Deploy notes

Requires `make restart` to recreate the grafana container with the new mount. Dashboards will auto-load within 30s.