### PR TITLE
fix: add explicit UIDs to Grafana provisioned datasources

### DIFF
--- a/services/grafana/provisioning/datasources/datasources.yaml
+++ b/services/grafana/provisioning/datasources/datasources.yaml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090
@@ -9,6 +10,7 @@ datasources:
     editable: false
 
   - name: Loki
+    uid: loki
     type: loki
     access: proxy
     url: http://loki:3100


### PR DESCRIPTION
## Summary

- Add explicit `uid` fields to Prometheus and Loki datasource provisioning
- Dashboard JSON files reference datasources by `uid: "prometheus"` and `uid: "loki"`, but without explicit UIDs Grafana auto-generates random ones, causing "datasource not found" errors on all panels

## Changes

- `services/grafana/provisioning/datasources/datasources.yaml` — add `uid: prometheus` and `uid: loki`

## Deploy notes

Requires nuking the Grafana volume before restart to avoid UID conflicts with existing auto-generated datasource records:

```bash
cd ~/infra
docker compose -f docker-compose.yml -f docker-compose.prod.yml stop grafana
docker compose -f docker-compose.yml -f docker-compose.prod.yml rm -f grafana
docker volume rm infra_grafana_data
docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d grafana
```