### PR TITLE
chore: harden security headers and pin dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,24 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
+    ignore:
+      # Major bumps require manual migration/validation
+      - dependency-name: "pgvector/pgvector"
+        update-types: [version-update:semver-major, version-update:semver-minor]
+      - dependency-name: "caddy"
+        update-types: [version-update:semver-major]
+      - dependency-name: "ghcr.io/umami-software/umami"
+        update-types: [version-update:semver-major]
+      - dependency-name: "louislam/uptime-kuma"
+        update-types: [version-update:semver-major]
+      - dependency-name: "grafana/grafana"
+        update-types: [version-update:semver-major]
+      - dependency-name: "grafana/loki"
+        update-types: [version-update:semver-major]
+      - dependency-name: "prom/prometheus"
+        update-types: [version-update:semver-major]
+      - dependency-name: "grafana/alloy"
+        update-types: [version-update:semver-major]
 
   # GitHub Actions versions
   - package-ecosystem: github-actions

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Auto-merge Dependabot
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+      - if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
         max-file: "3"
 
   umami:
-    # TODO: switch to pinned image
+    # No pinned postgresql-* tags available for v3 — only :postgresql-latest
     image: ghcr.io/umami-software/umami:postgresql-latest
     container_name: umami
     depends_on:

--- a/services/caddy/Caddyfile
+++ b/services/caddy/Caddyfile
@@ -11,10 +11,14 @@
 		X-Frame-Options "DENY" # Prevents clickjacking by disallowing the site to be framed
 		Referrer-Policy "strict-origin-when-cross-origin" # When navigating to another site, only sends the origin (not the full URL path). Prevents leaking private paths/query params to third parties.
 		Permissions-Policy "camera=(), microphone=(), geolocation=()" # Explicitly disables browser APIs you don't use
-		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		Strict-Transport-Security "max-age=63072000; includeSubDomains"
 		X-XSS-Protection "0" # Disables the deprecated XSS auditor, which can cause more harm than good. Included for legacy browser compatibility.
 		-Server # Strips the Server: Caddy header
 	}
+}
+
+(csp) {
+	header Content-Security-Policy "default-src 'self'; script-src 'self' https://analytics.victorpatrin.dev; connect-src 'self' https://analytics.victorpatrin.dev; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
 }
 
 # =============================================================================
@@ -27,6 +31,7 @@ www.victorpatrin.dev {
 
 victorpatrin.dev {
 	import security_headers
+	import csp
 	# Reduces bandwidth and speeds up page loads
 	encode zstd gzip
 	root * /srv/homepage
@@ -43,6 +48,7 @@ www.coupette.club {
 
 coupette.club {
 	import security_headers
+	import csp
 	encode zstd gzip
 	# API requests proxied to backend container
 	handle /api/* {


### PR DESCRIPTION
## Summary

- Add Content-Security-Policy header to `victorpatrin.dev` and `coupette.club` (allows Umami analytics script + beacon)
- Bump HSTS max-age from 1 year to 2 years
- Add Dependabot ignore rules to block major version bumps for all Docker images (pgvector also blocks minor)
- Add auto-merge workflow for Dependabot patch-level PRs
- Clarify Umami image comment (no pinned postgresql tags available for v3)

## Changes

- `services/caddy/Caddyfile` — CSP snippet with analytics origin allowlisted, HSTS max-age bump
- `.github/dependabot.yml` — ignore rules for major version bumps across all services
- `.github/workflows/dependabot-auto-merge.yml` — new workflow, auto-squash-merges patch updates only
- `docker-compose.yml` — comment clarification on Umami tag

## Deploy notes

Requires `make reload` on VPS to pick up Caddyfile changes. No container restart needed.