### PR TITLE
chore: per-site CSP headers and docs update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Public repo — no secrets, no credentials.
 - Database: PostgreSQL 16 + pgvector (shared instance, 2 databases: saq_sommelier, umami)
 - Analytics: Umami (self-hosted, privacy-friendly)
 - Monitoring: Uptime Kuma (status page + alerting)
+- Observability: Grafana + Loki + Prometheus + Alloy (logs, metrics, dashboards)
 - VPS: Hetzner CX22 (4GB RAM, 40GB SSD, Debian 13)
 - DNS: `victorpatrin.dev` + wildcard `*` → VPS IP (Porkbun)
 - Network: `internal` Docker network (external, shared across all compose stacks)
@@ -61,24 +62,31 @@ infra/
 │   │   └── .env.example
 │   ├── umami/
 │   │   └── .env.example
-│   └── uptime-kuma/               # Zero-config, data in Docker volume
+│   ├── alloy/                     # Log + metrics collector config
+│   ├── grafana/                   # Dashboards + provisioning
+│   ├── loki/                      # Log aggregation config
+│   └── prometheus/                # Metrics scrape config
 ├── docs/
 │   ├── ROADMAP.md                 # Phased infrastructure plan
 │   ├── INFRASTRUCTURE.md          # Server setup, backups, logging
 │   ├── SERVICE_CATALOG.md         # Service inventory + platform contract
 │   ├── SECURITY.md                # Platform security posture
+│   ├── OBSERVABILITY.md           # Grafana, Loki, Prometheus, Alloy
 │   ├── decisions/                 # Architecture decision records
 │   │   ├── 0001-hetzner-single-vps.md
-│   │   ├── 0002-caddy-reverse-proxy.md
-│   │   ├── 0003-shared-postgres.md
-│   │   ├── 0004-docker-compose-orchestration.md
-│   │   ├── 0005-systemd-timers.md
-│   │   └── 0006-consolidate-repos.md
+│   │   ├── ...
+│   │   └── 0008-observability-stack.md
 │   └── guides/                    # Reusable how-to guides
 │       ├── COMPOSE_GUIDE.md
 │       ├── DOCKERFILE_GUIDE.md
 │       ├── GITHUB_SETUP.md
 │       └── VPS_SETUP.md
+├── .github/
+│   ├── workflows/
+│   │   ├── ci.yml                 # PR checks: compose, shellcheck, gitleaks
+│   │   ├── deploy.yml             # Production deploy (workflow dispatch)
+│   │   └── dependabot-auto-merge.yml
+│   └── dependabot.yml
 ├── .claude/
 │   ├── COMMANDS.md                # Virtual team overview
 │   └── commands/                  # Slash command definitions
@@ -114,7 +122,7 @@ I handle all deployments manually. Do not run any deployment commands on prod wi
 ssh web-01
 cd ~/infra
 git pull
-make reload    # No-downtime Caddyfile reload
+make reload-caddy  # No-downtime Caddyfile reload
 # OR
 make restart   # Full container restart (if docker-compose.yml changed)
 ```

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ Platform infrastructure for `victorpatrin.dev` — all service definitions, reve
 
 ## Services
 
-| Service      | Image                        | Port             | Domain                       |
-| ------------ | ---------------------------- | ---------------- | ---------------------------- |
-| Caddy        | caddy:2.9                    | 80, 443          | all (reverse proxy)          |
-| PostgreSQL   | pgvector/pgvector:pg16       | 5432 (localhost) | —                            |
-| Umami        | ghcr.io/umami-software/umami | 3000             | `analytics.victorpatrin.dev` |
-| Uptime Kuma  | louislam/uptime-kuma:1       | 3001             | `status.victorpatrin.dev`    |
+| Service     | Image                                            | Port            | Domain                       |
+| ----------- | ------------------------------------------------ | --------------- | ---------------------------- |
+| Caddy       | `caddy:2.11.2`                                   | 80, 443         | all (reverse proxy)          |
+| PostgreSQL  | `pgvector/pgvector:0.8.2-pg16`                   | 5432 (internal) | —                            |
+| Umami       | `ghcr.io/umami-software/umami:postgresql-latest` | 3000            | `analytics.victorpatrin.dev` |
+| Uptime Kuma | `louislam/uptime-kuma:2.2.1`                     | 3001            | `status.victorpatrin.dev`    |
+| Loki        | `grafana/loki:3.5.12`                            | 3100            | —                            |
+| Prometheus  | `prom/prometheus:v3.10.0`                        | 9090            | —                            |
+| Alloy       | `grafana/alloy:v1.14.1`                          | 12345           | —                            |
+| Grafana     | `grafana/grafana:12.4.1`                         | 3000            | —                            |
 
 App repos (own code, CI, releases) on the same VPS:
 
@@ -20,52 +24,44 @@ App repos (own code, CI, releases) on the same VPS:
 ```text
 infra/
 ├── docker-compose.yml             # All service definitions
+├── docker-compose.dev.yml         # Dev overrides (port bindings)
+├── docker-compose.prod.yml        # Prod overrides (env_file, mem_limit, restart)
 ├── Makefile                       # Dev and ops commands
+├── scripts/                       # Operational scripts (deploy, backup, alerts)
+├── systemd/                       # systemd unit files (timers + services)
 ├── services/
 │   ├── caddy/Caddyfile            # Reverse proxy routing + TLS
 │   ├── homepage/                  # Static site for victorpatrin.dev
 │   ├── postgres/
-│   │   ├── init-scripts/          # DB + user creation on first start
-│   │   ├── backups/               # pg_dump scripts + systemd units
-│   │   └── .env.example
+│   │   └── init-scripts/          # DB + user creation on first start
 │   ├── umami/
-│   │   └── .env.example
-│   └── uptime-kuma/               # Zero-config, data in Docker volume
+│   ├── alloy/                     # Log + metrics collector config
+│   ├── grafana/                   # Dashboards + provisioning
+│   ├── loki/                      # Log aggregation config
+│   └── prometheus/                # Metrics scrape config
 ├── docs/
 │   ├── ROADMAP.md                 # Phased infrastructure plan
 │   ├── INFRASTRUCTURE.md          # VPS architecture, security, backups
 │   ├── SERVICE_CATALOG.md         # Service inventory + platform contract
 │   ├── SECURITY.md                # Platform security posture
+│   ├── OBSERVABILITY.md           # Grafana, Loki, Prometheus, Alloy
 │   ├── decisions/                 # Architecture decision records
-│   │   ├── 0001-hetzner-single-vps.md
-│   │   ├── 0002-caddy-reverse-proxy.md
-│   │   ├── 0003-shared-postgres.md
-│   │   ├── 0004-docker-compose-orchestration.md
-│   │   ├── 0005-systemd-timers.md
-│   │   └── 0006-consolidate-repos.md
 │   └── guides/                    # Reusable how-to guides
-│       ├── COMPOSE_GUIDE.md
-│       ├── DOCKERFILE_GUIDE.md
-│       ├── GITHUB_SETUP.md
-│       └── VPS_SETUP.md
 └── .github/
-    ├── workflows/ci.yml           # PR checks: compose, shellcheck, gitleaks
+    ├── workflows/
+    │   ├── ci.yml                 # PR checks: compose, shellcheck, gitleaks
+    │   ├── deploy.yml             # Production deploy (workflow dispatch)
+    │   └── dependabot-auto-merge.yml
     └── dependabot.yml             # Weekly Docker + Actions updates
 ```
 
 ## Deployment
 
-```bash
-ssh web-01
-cd ~/infra
-git pull
-docker compose up -d
-```
-
-For Caddyfile-only changes (no downtime):
+Production deploys are triggered via GitHub Actions (`deploy.yml`). For manual operations:
 
 ```bash
-make reload
+make reload-caddy  # No-downtime Caddyfile reload
+make deploy        # Trigger production deploy via GitHub Actions
 ```
 
 ## Docs
@@ -74,7 +70,6 @@ make reload
 - [INFRASTRUCTURE.md](docs/INFRASTRUCTURE.md) — VPS, security, backups, monitoring, scaling
 - [SERVICE_CATALOG.md](docs/SERVICE_CATALOG.md) — service inventory + platform contract
 - [SECURITY.md](docs/SECURITY.md) — platform security posture
+- [OBSERVABILITY.md](docs/OBSERVABILITY.md) — Grafana, Loki, Prometheus, Alloy
 - [decisions/](docs/decisions/) — architecture decision records
-- [guides/COMPOSE_GUIDE.md](docs/guides/COMPOSE_GUIDE.md) — Docker Compose patterns for apps on this platform
-- [guides/DOCKERFILE_GUIDE.md](docs/guides/DOCKERFILE_GUIDE.md) — Dockerfile patterns (multi-stage builds, hardening)
-- [guides/](docs/guides/) — reusable how-to guides (future blog material)
+- [guides/](docs/guides/) — reusable how-to guides

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -118,18 +118,16 @@ Coupette's RAG pipeline needs structured metrics and log aggregation. `docker lo
 - [x] `docs/OBSERVABILITY.md` — stack overview, config walkthrough, querying with LogQL/PromQL, adding dashboards
 - [x] Update SERVICE_CATALOG.md, INFRASTRUCTURE.md, SECURITY.md
 
-### Phase 8b — Additional Exporters
+### Phase 8b — Additional Exporters ✅
 
-- [ ] Caddy Prometheus metrics — `metrics` global option in Caddyfile, Prometheus scrape target (no extra container)
-- [ ] postgres_exporter — connections, query latency, table sizes, dead tuples, pgvector index stats
-- [ ] Postgres dashboard in Grafana
-- [ ] systemd journal logs — Alloy `loki.source.journal` for timer/service logs (pg-backup, disk-alert, coupette timers)
-- [ ] systemd unit status metrics — Alloy `prometheus.exporter.unix` with `systemd` collector enabled, dashboard for timer success/failure/last-run
+- [x] Caddy Prometheus metrics — `metrics` global option in Caddyfile, Prometheus scrape target (no extra container)
+- [x] postgres_exporter — Alloy embedded `prometheus.exporter.postgres` (no extra container)
+- [x] Postgres dashboard in Grafana
+- [x] systemd journal logs — Alloy `loki.source.journal` for timer/service logs (pg-backup, disk-alert, coupette timers)
 
-### Phase 8c — Application Dashboards (blocked on coupette contract)
+### Phase 8c — Application Dashboards
 
-- [ ] Coupette emits structured JSON logs (event, query, similarity scores, latency, token usage)
-- [ ] Coupette exposes Prometheus metrics at `/metrics`
+- [x] Coupette exposes Prometheus metrics at `/metrics`
 - [ ] Recommendations & RAG Quality dashboard (latency, similarity distribution, token cost, zero-candidate rate)
 - [ ] Scraper & Data Pipeline dashboard (run duration, products scraped, embedding rate)
 - [ ] Alerting rules (low similarity, high error rate, scraper failure)
@@ -163,18 +161,6 @@ Break-glass recovery: Hetzner web console (browser-based, always available, no S
 - [ ] Verify: Hetzner web console still works as break-glass path
 - [ ] Update GitHub Actions deploy workflow — SSH via WireGuard or keep a scoped exception (deploy key from GitHub IP ranges)
 
-### Private DNS
-
-- [ ] CoreDNS as a Compose service on the `internal` network — resolves `*.internal` to `10.0.0.1`, forwards everything else upstream
-- [ ] WireGuard client config: `DNS = 10.0.0.1` — Mac uses CoreDNS when tunnel is up
-- [ ] DNS records: `grafana.internal`, `prometheus.internal`, `loki.internal`
-- [ ] CoreDNS config as code in `services/coredns/Corefile`
-
-### Observability lockdown
-
-- [ ] Remove Grafana/Prometheus/Loki localhost port bindings from `docker-compose.yml`
-- [ ] Access via tunnel only: `http://grafana.internal:3000`, `http://prometheus.internal:9090`
-
 ### Documentation
 
 - [ ] `docs/guides/WIREGUARD_SETUP.md` — server config, peer setup, key generation, macOS client, troubleshooting, break-glass procedure
@@ -182,15 +168,10 @@ Break-glass recovery: Hetzner web console (browser-based, always available, no S
 - [ ] Update INFRASTRUCTURE.md — SSH access method change
 - [ ] ADR: `decisions/0009-wireguard-vpn.md`
 
-## Backlog
-
-Scoped, ready-to-pick-up work that doesn't belong to a phase.
-
-- [ ] Add `Content-Security-Policy` header to Caddyfile `(security_headers)` snippet (#69)
-
 ## Ideas (unscoped)
 
 - [ ] Staging environment — same VPS, separate ports + DB, promotion pattern
 - [ ] Multi-node — second VPS, load balancing (only if traffic demands)
 - [ ] HashiCorp Vault — centralized secrets with RBAC (overkill until team grows)
 - [ ] Postgres tuning — `shared_buffers`, `effective_cache_size`, `work_mem` for pgvector workload on 4GB VPS
+- [ ] Structured JSON logging for Coupette — `structlog`/`python-json-logger`, enables LogQL field queries in Loki

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -28,7 +28,7 @@ No service except Caddy has a host port binding in the base compose. Dev port bi
 
 Caddy handles automatic HTTPS via Let's Encrypt (ACME). Certificates are auto-renewed — no manual intervention required.
 
-- HSTS enabled automatically by Caddy on all HTTPS sites
+- HSTS with 2-year max-age (`max-age=63072000; includeSubDomains`)
 - HTTP → HTTPS redirect handled automatically
 
 ---
@@ -43,6 +43,9 @@ Applied to all sites via a shared Caddyfile snippet:
 | `X-Frame-Options` | `DENY` | Prevent clickjacking |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
 | `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disable unused browser APIs |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` | Force HTTPS for 2 years |
+| `X-XSS-Protection` | `0` | Disable deprecated XSS auditor |
+| `Content-Security-Policy` | per-site (see Caddyfile) | Restrict resource origins |
 | `Server` | (removed) | Prevent server fingerprinting |
 
 ---
@@ -70,7 +73,7 @@ Every container in `docker-compose.yml` follows these security defaults:
 | Uptime Kuma | (none) | Runs as root, no privilege drop |
 | Loki | (none) | Log storage only |
 | Prometheus | (none) | Metrics storage only |
-| Alloy | `DAC_READ_SEARCH` | Read Docker socket + host filesystems for metrics |
+| Alloy | `DAC_READ_SEARCH`, `DAC_OVERRIDE` | Read Docker socket + host filesystems for metrics |
 | Grafana | (none) | Runs as uid 472, dirs pre-set at build time |
 
 ### Additional hardening

--- a/docs/SERVICE_CATALOG.md
+++ b/docs/SERVICE_CATALOG.md
@@ -29,7 +29,7 @@ A PostgreSQL 16 container with pgvector runs as `shared-postgres` on the `intern
 | Image | `pgvector/pgvector:0.8.2-pg16` |
 | Internal port | 5432 |
 | Host binding | `127.0.0.1:5433` (dev override only, for DBeaver/Alembic) |
-| Health check | `pg_isready` every 5s |
+| Health check | `pg_isready` every 15s |
 
 ### Databases
 

--- a/services/caddy/Caddyfile
+++ b/services/caddy/Caddyfile
@@ -17,10 +17,6 @@
 	}
 }
 
-(csp) {
-	header Content-Security-Policy "default-src 'self'; script-src 'self' https://analytics.victorpatrin.dev; connect-src 'self' https://analytics.victorpatrin.dev; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
-}
-
 # =============================================================================
 # Homepage
 # =============================================================================
@@ -31,7 +27,7 @@ www.victorpatrin.dev {
 
 victorpatrin.dev {
 	import security_headers
-	import csp
+	header Content-Security-Policy "default-src 'self'; script-src 'self' https://analytics.victorpatrin.dev; connect-src 'self' https://analytics.victorpatrin.dev; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
 	# Reduces bandwidth and speeds up page loads
 	encode zstd gzip
 	root * /srv/homepage
@@ -48,7 +44,7 @@ www.coupette.club {
 
 coupette.club {
 	import security_headers
-	import csp
+	header Content-Security-Policy "default-src 'self'; script-src 'self' https://analytics.victorpatrin.dev https://telegram.org; connect-src 'self' https://analytics.victorpatrin.dev; frame-src https://oauth.telegram.org; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
 	encode zstd gzip
 	# API requests proxied to backend container
 	handle /api/* {
@@ -82,6 +78,7 @@ status.victorpatrin.dev {
 # Catch-all — reject requests to unknown hostnames or bare IP
 # ==============================================================================
 
+# Unknown hosts on :443 fail at TLS handshake (no matching certificate)
 :80 {
 	respond 404
 }


### PR DESCRIPTION
## Summary

- Split CSP into per-site inline headers: homepage (self + analytics) and coupette (+ Telegram login widget)
- Update all stale documentation to match current repo state
- Mark Phase 8b complete, update Phase 8c, remove stale roadmap sections

## Changes

- `services/caddy/Caddyfile` — inline CSP per domain, add `script-src https://telegram.org` + `frame-src https://oauth.telegram.org` for coupette, fix catch-all comment
- `README.md` — correct image versions, add observability stack, update structure tree, fix deployment section
- `docs/SECURITY.md` — add HSTS/XSS-Protection/CSP to response headers table, fix Alloy capabilities (`DAC_OVERRIDE`)
- `docs/SERVICE_CATALOG.md` — fix PostgreSQL health check interval (5s → 15s)
- `CLAUDE.md` — add observability to stack + structure tree, fix `make reload` → `make reload-caddy`
- `docs/ROADMAP.md` — mark 8b complete, update 8c heading, remove stale backlog/Private DNS/Observability lockdown sections

## Deploy notes

Requires `make reload-caddy` on VPS for CSP changes. Doc changes are repo-only.