### PR TITLE
fix: add unsafe-eval to coupette CSP for Telegram widget

### DIFF
--- a/services/caddy/Caddyfile
+++ b/services/caddy/Caddyfile
@@ -44,7 +44,7 @@ www.coupette.club {
 
 coupette.club {
 	import security_headers
-	header Content-Security-Policy "default-src 'self'; script-src 'self' https://analytics.victorpatrin.dev https://telegram.org; connect-src 'self' https://analytics.victorpatrin.dev; frame-src https://oauth.telegram.org; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
+	header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://analytics.victorpatrin.dev https://telegram.org; connect-src 'self' https://analytics.victorpatrin.dev; frame-src https://oauth.telegram.org; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
 	encode zstd gzip
 	# API requests proxied to backend container
 	handle /api/* {


### PR DESCRIPTION
## Summary

- Add `'unsafe-eval'` to `script-src` on `coupette.club` — the Telegram login widget uses `eval()` internally

## Changes

- `services/caddy/Caddyfile` — add `'unsafe-eval'` to coupette's CSP `script-src` directive only (homepage stays strict)

## Deploy notes

Requires `make reload-caddy` on VPS.