### PR TITLE
fix: remove Loki health check (distroless image has no wget)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
       - ./services/grafana/dashboards:/etc/grafana/dashboards:ro
     depends_on:
       loki:
-        condition: service_healthy
+        condition: service_started
       prometheus:
         condition: service_healthy
     networks:


### PR DESCRIPTION
## Summary

- Loki 3.6.7 ships a distroless image with no `wget`, `curl`, `sh`, or `ls` — the health check fails on every run, marking Loki as unhealthy
- Alloy and Grafana depend on `service_healthy`, so they fail to start when Loki is unhealthy

## Changes

- `docker-compose.yml` — remove Loki health check (no tools available in the image to run it), change Alloy and Grafana's Loki dependency from `service_healthy` to `service_started`

## Deploy notes

Requires `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d` on VPS to recreate Loki, Alloy, and Grafana containers.