### PR TITLE
fix: remove Loki from deploy health checks

### DIFF
--- a/scripts/deploy_infra.sh
+++ b/scripts/deploy_infra.sh
@@ -98,7 +98,6 @@ check_health_inspect "postgres"   "shared-postgres"
 check_health_inspect "caddy"
 check_health_inspect "umami"
 check_health_inspect "uptime-kuma"
-check_health_inspect "loki"
 check_health_inspect "prometheus"
 check_health_inspect "grafana"
 


### PR DESCRIPTION
## Summary

- Remove Loki from deploy health check since Loki 3.6.7 is distroless (no health check in compose)

## Changes

- `scripts/deploy_infra.sh` — remove `check_health_inspect "loki"` (no health status to inspect after PR #94 removed the compose health check)

## Deploy notes

No VPS action needed — this only affects future deploys.