### PR TITLE
docs: ADR 0009 disaster recovery strategy + roadmap update (#99)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,30 +88,31 @@ Coupette's RAG pipeline needs structured metrics and log aggregation. `docker lo
 ## Phase 5 — Disaster Recovery
 
 **Context:** web-01 is a single point of failure. If it dies, recovery is manual — SSH in, re-provision, restore from backups. No runbook, no automation, no offsite backups.
-**Action:** Daily Postgres dumps to Hetzner Object Storage with tiered retention. Terraform for VPS provisioning. Ansible for full server configuration. DR runbook with tested recovery flow.
+**Action:** Daily Postgres dumps to AWS S3 (provider diversity). Terraform for VPS provisioning (state in Hetzner Object Storage). Ansible for full server configuration. DR runbook with tested recovery flow.
 
 ### Backup strategy
 
-- [ ] Daily Postgres dumps (all DBs) → Hetzner Object Storage — 3-tier retention (daily 7d / weekly 4w / monthly 3m)
-- [ ] Backup script updated — offload to object storage, prune per retention policy
+- [ ] Daily Postgres dumps (all DBs) → AWS S3 — 3-tier retention (daily 7d / weekly 4w / monthly 3m)
+- [ ] Backup script rewritten — S3 as primary (no local retention), fail loudly on upload failure
 - [ ] Restore smoke test — verify current dumps restore into a throwaway container before trusting offsite
 
 ### Terraform
 
 - [ ] Hetzner VPS (Debian 13) + SSH key registration
 - [ ] Hetzner firewall rules (22, 80, 443)
+- [ ] State backend in Hetzner Object Storage (bucket created manually)
 - [ ] CI gate — `terraform validate` on PR
 - [ ] Outputs VPS IP for Ansible inventory
 
 ### Ansible
 
 - [ ] `requirements.yml` — `geerlingguy.security`, `geerlingguy.docker`
-- [ ] `roles/base` — swap, timezone, locale, Docker log rotation, sops
+- [ ] `roles/base` — swap, timezone, locale, Docker log rotation, sops + age
 - [ ] `roles/security` — SSH hardening, fail2ban, ufw (wraps `geerlingguy.security`)
 - [ ] `roles/docker` — Docker + Compose plugin (wraps `geerlingguy.docker`)
-- [ ] `roles/infra` — clone infra + coupette repos, `internal` network, compose up, `deploy_infra.sh`
-- [ ] `roles/timers` — provision infra systemd units (pg-backup, disk-alert, push monitors)
-- [ ] Ansible vault — all secrets (Postgres, Umami, Telegram token, push monitor URLs, Hetzner Object Storage credentials, SSH deploy key public key, coupette `.env`)
+- [ ] `roles/infra` — clone infra + coupette repos, `internal` network, sops-encrypted `.env.prod` files, compose up (all services incl. observability stack)
+- [ ] `roles/timers` — provision systemd units (pg-backup, disk-alert)
+- [ ] Ansible vault — sops age key, SSH deploy key, AWS S3 credentials, Hetzner Object Storage credentials, push monitor URLs
 - [ ] CI gate — `ansible-lint` on PR
 
 ### DR runbook + validation
@@ -180,12 +181,11 @@ Coupette's RAG pipeline needs structured metrics and log aggregation. `docker lo
 
 Concrete housekeeping — not phased, ship when convenient.
 
-- [ ] Rename `saq_sommelier` in backup script (#21)
-- [ ] GitHub production environment for deploy workflow (#54)
-- [ ] Move `git pull` out of `deploy_infra.sh` into CI workflow (#76)
-- [ ] Umami crash-loop — Prisma schema-engine missing for ARM64 (#77)
+- [ ] Rename `saq_sommelier` in backup script — blocked on coupette DB rename (#21, coupette #423)
 - [ ] Rename uptime-kuma volume to follow naming convention (#79)
 - [ ] Enable `pg_stat_statements` for query monitoring (#96)
+- [ ] Run security hardening audits — docker-bench, Lynis, ssh-audit (#56). Informs Phase 9.
+- [ ] Evaluate GitHub organization for shared workflows (#73)
 
 ## Ideas (unscoped)
 

--- a/docs/decisions/0009-disaster-recovery.md
+++ b/docs/decisions/0009-disaster-recovery.md
@@ -1,0 +1,79 @@
+# ADR 0009: Disaster Recovery Strategy
+
+**Date:** 2026-03-22
+**Status:** Accepted
+
+## Context
+
+web-01 (Hetzner CX22) is a single point of failure. If the VPS dies — hardware failure, account issue, bad deploy — recovery is manual: re-provision via Hetzner console, walk through a 17-step VPS setup guide, restore Postgres from local backups that live on the same disk. Local backups don't survive disk failure. There's no tested recovery path.
+
+The platform now runs 8 containers (Caddy, Postgres, Umami, Uptime Kuma, Grafana, Loki, Prometheus, Alloy) plus coupette's app services. Manual recovery would take hours and is error-prone.
+
+## Options considered
+
+1. **Improve the runbook** — keep manual setup, just document it better. Zero automation cost, but recovery time stays at 2-4 hours and depends on operator memory under stress. Doesn't solve the offsite backup problem.
+
+2. **Offsite backups only** — upload Postgres dumps to cloud storage, keep manual provisioning. Solves data loss but recovery still requires 17 manual steps. The most valuable single change, but leaves automation on the table.
+
+3. **Terraform + Ansible + offsite backups** — automate VPS provisioning (Terraform) and server configuration (Ansible), store backups off-provider (AWS S3). Recovery becomes: `terraform apply`, `ansible-playbook site.yml`, restore Postgres, update DNS. Tested end-to-end with a throwaway VPS.
+
+4. **Full GitOps (K3s + Flux)** — skip Compose-era DR, go straight to Kubernetes with declarative everything. Solves DR but introduces K3s complexity before the platform needs it. Over-engineers the current single-VPS setup.
+
+## Decision
+
+Option 3: Terraform + Ansible + offsite backups.
+
+- **Backups → AWS S3** for provider diversity. If Hetzner has an outage or account issue, backups survive. No local retention — S3 is the primary store. 3-tier retention: daily 7d, weekly 4w, monthly 3m.
+- **Terraform → Hetzner API** for VPS provisioning. State stored in Hetzner Object Storage (provisioning Hetzner infra, so state stays with the provider). Bucket created manually (one-time, like DNS).
+- **Ansible → fresh VPS** for full server configuration. 5 roles: base, security, docker, infra, timers. Ansible vault for bootstrap secrets (`~/.ansible_vault_pass`). App secrets stay in sops-encrypted `.env.prod.enc` files — Ansible places the age key, future deploys decrypt.
+- **Ansible scope is DR only.** It provisions a fresh server. It does not handle ongoing CD (that's GitHub Actions) or app deploys (that's coupette's own CI/CD).
+
+### Manual vs automated boundary
+
+```
+MANUAL (one-time or rare)
+  AWS S3 bucket creation
+  Hetzner Object Storage bucket creation
+  Porkbun DNS update (A record → new VPS IP)
+  ~/.ansible_vault_pass (from password manager)
+  Postgres restore from S3 (verified before DNS cutover)
+
+TERRAFORM (laptop → Hetzner API)
+  VPS (Debian 13, CX22)
+  Cloud firewall (22, 80, 443)
+  SSH key registration
+  → outputs: VPS IP
+
+ANSIBLE (laptop → fresh VPS)
+  OS: swap, timezone, locale, log rotation
+  Security: SSH hardening, fail2ban, ufw
+  Docker: Docker CE + Compose plugin
+  Infra: clone repos, internal network, external volumes,
+         place age key, sops decrypt, compose up
+  Timers: pg-backup, disk-alert systemd units
+
+APP-OWNED (after infra is up)
+  Coupette deploy (tag-push → GitHub Actions)
+```
+
+### RTO/RPO targets
+
+- **RPO (data loss):** ≤ 24 hours. Daily Postgres dumps to S3. Acceptable — the app is a wine recommender, not a payment system.
+- **RTO (recovery time):** < 1 hour. Terraform + Ansible + restore + DNS. Manual recovery would take hours.
+
+## Rationale
+
+- Provider diversity: AWS S3 for backups survives a Hetzner outage. Terraform state in Hetzner Object Storage is fine — if Hetzner is down, you can't provision there anyway.
+- Ansible codifies the VPS setup guide as a runnable artifact. The 17-step manual process becomes a playbook that's tested against a throwaway VPS before it's needed.
+- Keeping Ansible scoped to DR avoids the complexity of Ansible-as-CD. GitHub Actions SSH-based deploy already works for both repos.
+- `aws-cli` for S3 uploads is a first step into AWS tooling — transferable skills.
+- Fail-loud backup script (exit non-zero on upload failure) ensures Uptime Kuma alerts on backup problems.
+
+## Consequences
+
+- Two new directories (`terraform/`, `ansible/`) to maintain. CI gates (`terraform validate`, `ansible-lint`) prevent rot.
+- AWS account required (free tier covers S3 for this volume). Separate bill from Hetzner.
+- Hetzner Object Storage bucket required for Terraform state. Manual one-time creation.
+- Ansible vault password is a new secret to manage (password manager only, `~/.ansible_vault_pass` on laptop).
+- DR test costs ~€0.02 (a CX22 for 1-2 hours). Should be re-run after major infrastructure changes.
+- Raspberry Pi home storage planned as a future secondary backup target (not in this phase).


### PR DESCRIPTION
## Summary

- ADR 0009: documents DR strategy decisions — AWS S3 for backups (provider diversity), Hetzner Object Storage for Terraform state, Ansible scoped to DR only, RTO/RPO targets, manual vs automated boundary diagram
- ROADMAP.md: Phase 5 updated with agreed decisions (S3 split, vault secrets, role scope), backlog trimmed of stale items

## Changes

- `docs/decisions/0009-disaster-recovery.md` (new) — full ADR with options considered, decision, rationale, consequences
- `docs/ROADMAP.md` — Phase 5 backup/Terraform/Ansible sections updated, backlog cleaned (dropped #54, #70, #74, #76, #77; kept #21, #56, #73, #79, #96)

## Deploy notes

None — docs only.

Closes #99