### PR TITLE
fix: decrypt infra secrets to repo instead of /etc/infra

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,7 +96,7 @@ s3://victorpatrin-backups/postgres/
 
 Handled automatically by `deploy_infra.sh` — it syncs all units from `systemd/` to `/etc/systemd/system/`.
 
-AWS credentials for the `infra-backup` IAM user are in `/etc/infra/aws-infra-backup.env` (root-owned, `0600`). Contains `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, and `S3_BUCKET`.
+AWS credentials for the `infra-backup` IAM user are in `secrets/aws-infra-backup.env` (decrypted from `.env.enc` by `deploy_infra.sh`). Contains `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, and `S3_BUCKET`.
 
 ### Manual backup
 
@@ -167,7 +167,7 @@ Uptime Kuma polls services via HTTP and alerts on downtime via Telegram (`@victo
 
 Daily systemd timer checks disk usage on `/`. If usage exceeds 85%, sends a Telegram alert via `@victor_uptime_bot`. Not routed through Uptime Kuma — the timer always runs and the disk is always queryable, so push/pull monitoring doesn't apply.
 
-Credentials (`BOT_TOKEN`, `CHAT_ID`) stored in `secrets/telegram-alerts-bot.env.enc` (sops-encrypted), decrypted to `/etc/infra/telegram-alerts-bot.env` by `deploy_infra.sh`.
+Credentials (`BOT_TOKEN`, `CHAT_ID`) stored in `secrets/telegram-alerts-bot.env.enc` (sops-encrypted), decrypted to `secrets/telegram-alerts-bot.env` by `deploy_infra.sh`.
 
 ### Push monitors (systemd timers)
 
@@ -177,7 +177,7 @@ Scheduled jobs (backups, scrapers) report success to Uptime Kuma push monitors. 
 |--------------|--------------|-----------|---------|
 | `pg-backup`  | Push         | 1 day     | 6 hours |
 
-Push URLs are stored in `/etc/infra/<monitor>.env` on the VPS (root-owned, `0600`). Systemd loads them via `EnvironmentFile`, and `ExecStartPost=-` calls `scripts/push-monitor.sh` on success. See `pg-backup.service` for the reference implementation.
+Push URLs are stored in `secrets/<monitor>.env.enc` (sops-encrypted), decrypted to `secrets/<monitor>.env` by `deploy_infra.sh`. Systemd loads them via `EnvironmentFile`, and `ExecStartPost=-` calls `scripts/push-monitor.sh` on success. See `pg-backup.service` for the reference implementation.
 
 #### Adding a push monitor
 

--- a/scripts/deploy_infra.sh
+++ b/scripts/deploy_infra.sh
@@ -29,12 +29,10 @@ echo "==> Decrypting secrets..."
     done
 
     # Infra-level secrets (host systemd timers, push monitors)
-    sudo mkdir -p /etc/infra
     for secret in "${ENCRYPTED_SECRETS[@]}"; do
         enc="${INFRA_DIR}/secrets/${secret}.env.enc"
         [[ -f "${enc}" ]] || { echo "ERROR: ${enc} not found"; exit 1; }
-        sops --decrypt --output-type dotenv "${enc}" | sudo tee "/etc/infra/${secret}.env" > /dev/null
-        sudo chmod 600 "/etc/infra/${secret}.env"
+        sops --decrypt --output-type dotenv "${enc}" > "${INFRA_DIR}/secrets/${secret}.env"
     done
 )
 
@@ -47,8 +45,8 @@ for svc in "${ENCRYPTED_SERVICES[@]}"; do
     fi
 done
 for secret in "${ENCRYPTED_SECRETS[@]}"; do
-    env_file="/etc/infra/${secret}.env"
-    if ! sudo test -s "${env_file}"; then
+    env_file="${INFRA_DIR}/secrets/${secret}.env"
+    if [[ ! -s "${env_file}" ]]; then
         echo "ERROR: ${env_file} is empty after decryption"
         exit 1
     fi

--- a/systemd/disk-alert.service
+++ b/systemd/disk-alert.service
@@ -5,6 +5,6 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-EnvironmentFile=/etc/infra/telegram-alerts-bot.env
+EnvironmentFile=/home/deploy/infra/secrets/telegram-alerts-bot.env
 ExecStart=/home/deploy/infra/scripts/disk-alert.sh
 User=victor

--- a/systemd/pg-backup.service
+++ b/systemd/pg-backup.service
@@ -5,8 +5,8 @@ Requires=docker.service
 
 [Service]
 Type=oneshot
-EnvironmentFile=/etc/infra/aws-infra-backup.env
-EnvironmentFile=/etc/infra/monitor-backups.env
+EnvironmentFile=/home/deploy/infra/secrets/aws-infra-backup.env
+EnvironmentFile=/home/deploy/infra/secrets/monitor-backups.env
 ExecStart=/home/deploy/infra/scripts/postgres_backup.sh
 ExecStartPost=-/home/deploy/infra/scripts/push-monitor.sh ${PUSH_URL}
 User=victor


### PR DESCRIPTION
## Summary

- Decrypt infra-level secrets (`secrets/*.env.enc`) to `secrets/*.env` in the repo instead of `/etc/infra/`
- Removes all sudo calls from secret decryption — `deploy` user already owns the repo
- Systemd units point to `/home/deploy/infra/secrets/` instead of `/etc/infra/`
- No more root filesystem writes for secrets (only `/etc/systemd/system/` remains, which is required by systemd)

## Changes

- `scripts/deploy_infra.sh` — decrypt to `${INFRA_DIR}/secrets/`, remove `sudo mkdir/tee/chmod/test`
- `systemd/pg-backup.service` — EnvironmentFile paths → repo
- `systemd/disk-alert.service` — EnvironmentFile path → repo
- `docs/ARCHITECTURE.md` — updated secret paths in backup, disk alert, and push monitor sections

## Deploy notes

After merge + CD:
1. Verify secrets decrypt: `ls -la ~/infra/secrets/*.env`
2. Test backup: `sudo systemctl start pg-backup.service`
3. Clean up: `sudo rm -rf /etc/infra/`