### PR TITLE
fix: use temp file for S3 backup upload + document deploy home permissions

### DIFF
--- a/docs/guides/VPS_SETUP_GUIDE.md
+++ b/docs/guides/VPS_SETUP_GUIDE.md
@@ -483,11 +483,14 @@ A dedicated `deploy` user runs CI workloads (GitHub Actions). It is separate fro
 ```bash
 sudo adduser --disabled-password --gecos '' deploy
 sudo usermod -aG docker deploy
+sudo chmod 711 /home/deploy
 ```
 
 `--disabled-password` means no password and no password-based login. SSH key only. No sudo.
 
 Adding `deploy` to the `docker` group allows it to run `docker compose` commands without root.
+
+`chmod 711` allows other users (e.g. `victor` running systemd timers) to traverse `/home/deploy/` without being able to list its contents. Required because systemd units run as `victor` but reference scripts and secrets in `/home/deploy/infra/`.
 
 ### Scoped sudo for systemd
 

--- a/scripts/postgres_backup.sh
+++ b/scripts/postgres_backup.sh
@@ -19,12 +19,19 @@ if [[ $# -ge 1 ]]; then
     DATABASES=("$1")
 fi
 
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
 for db in "${DATABASES[@]}"; do
+    file="${WORK_DIR}/${db}_${DATE}.sql.gz"
     s3_path="s3://${S3_BUCKET}/${S3_PREFIX}/${db}/${DATE}.sql.gz"
 
-    echo "Dumping ${db} → ${s3_path}..."
-    docker exec "${CONTAINER}" pg_dump -U "${PG_USER}" "${db}" | gzip | \
-        aws s3 cp - "${s3_path}" --quiet
+    echo "Dumping ${db}..."
+    docker exec "${CONTAINER}" pg_dump -U "${PG_USER}" "${db}" | gzip > "${file}"
+    echo "  dumped: $(du -h "${file}" | cut -f1)"
+
+    echo "  uploading to ${s3_path}..."
+    aws s3 cp "${file}" "${s3_path}" --quiet
     echo "  uploaded"
 done
 


### PR DESCRIPTION
## Summary

- Revert streaming `pg_dump | gzip | aws s3 cp -` to temp file approach — stdin upload hangs on VPS
- Document `chmod 711 /home/deploy` in VPS setup guide (needed for systemd units running as `victor` to access deploy-owned scripts/secrets)

## Changes

- `scripts/postgres_backup.sh` — dump to temp file, upload, trap cleans up on exit
- `docs/guides/VPS_SETUP_GUIDE.md` — added `chmod 711` step with explanation

## Deploy notes

After merge + CD:
1. `sudo systemctl stop pg-backup.service` (kill stuck process if still running)
2. `sudo systemctl start pg-backup.service`
3. `journalctl -u pg-backup.service --no-pager`