### PR TITLE
fix: dashboard overhaul, cAdvisor containerd socket, and backup hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up down dev-homepage logs status validate-caddy reload-caddy deploy tunnel
+.PHONY: help up down dev-homepage logs status validate-caddy reload-caddy deploy tunnel create-secret edit-secret
 
 COMPOSE := docker compose -f docker-compose.yml -f docker-compose.dev.yml
 
@@ -37,3 +37,12 @@ deploy: ## Trigger production deploy via GitHub Actions
 	@read -p "Type 'approve' to continue: " confirm && [ "$$confirm" = "approve" ] || { echo "Aborted."; exit 1; }
 	gh workflow run deploy
 	@echo "Deploy triggered. Watch: gh run watch"
+
+create-secret: ## Encrypt a .env file: make create-secret FILE=secrets/aws-infra-backup.env
+	@test -n "$(FILE)" || { echo "Usage: make create-secret FILE=secrets/<name>.env"; exit 1; }
+	sops --encrypt --input-type dotenv --output-type json "$(FILE)" > "$(FILE).enc.tmp" && mv "$(FILE).enc.tmp" "$(FILE).enc" && rm "$(FILE)"
+	@echo "Encrypted: $(FILE).enc"
+
+edit-secret: ## Edit an encrypted secret: make edit-secret FILE=secrets/aws-infra-backup.env.enc
+	@test -n "$(FILE)" || { echo "Usage: make edit-secret FILE=secrets/<name>.env.enc"; exit 1; }
+	sops --input-type json --output-type json "$(FILE)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,21 +166,20 @@ services:
     volumes:
       - ./services/alloy:/etc/alloy:ro
       - alloy_data:/var/lib/alloy/data
-      # Docker socket for log collection
-      # TODO: evaluate security implications of this mount, and consider alternatives like a log forwarder sidecar or journald socket (if we switch to journald for container logging).
+      # loki.source.docker + cadvisor: container log tailing + container discovery
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      # /proc: CPU, memory, load, network counters
-      - /proc:/host/proc:ro
-      # /sys: hardware topology, device stats
-      - /sys:/host/sys:ro
-      # rootfs: disk capacity, usage, inodes (node_filesystem_* metrics)
-      - /:/host/root:ro
-      # cgroup v2: per-container CPU, memory, I/O accounting
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-      # Docker data: container metadata for cAdvisor metrics
-      - /var/lib/docker:/var/lib/docker:ro
-      # Systemd journal: timer/service logs (pg-backup, disk-alert, coupette timers)
+      # loki.source.journal: systemd timer/service logs
       - /var/log/journal:/var/log/journal:ro
+      # node_exporter (procfs_path): CPU, memory, load, network counters
+      - /proc:/host/proc:ro
+      # node_exporter (sysfs_path): hardware topology, device stats
+      - /sys:/host/sys:ro
+      # node_exporter (rootfs_path): disk capacity, usage, inodes
+      - /:/host/root:ro
+      # cadvisor: container metadata, overlay filesystem info
+      - /var/lib/docker:/var/lib/docker:ro
+      # cadvisor: containerd runtime socket for per-container metrics
+      - /run/containerd/containerd.sock:/run/containerd/containerd.sock:ro
     depends_on:
       loki:
         condition: service_started

--- a/secrets/aws-infra-backup.env.enc
+++ b/secrets/aws-infra-backup.env.enc
@@ -1,21 +1,21 @@
 {
-	"AWS_ACCESS_KEY_ID": "ENC[AES256_GCM,data:MC7OCwetVZ1uYOUDtyn1hVmYGcGl/5I=,iv:HFsGkmRsHuk7cBS0vKnqfjSpnXlVmqAk4IDrAZlPx6o=,tag:/j8VOJbtmFa0mNedjUsBHg==,type:str]",
-	"AWS_SECRET_ACCESS_KEY": "ENC[AES256_GCM,data:1E9dqcbb503tRVuuXaqWWVd3F5EhwzS6FYE=,iv:3HoQq934oM5SN/8vXah3wACPy59JqoTmzNIqy7uUKeI=,tag:3XloqdgkvGsIPpjKw0WTrQ==,type:str]",
-	"AWS_DEFAULT_REGION": "ENC[AES256_GCM,data:NTCfNI3tKuT9Eu8I,iv:jHlrNxMWNiJt7+cY6cB+mUFQj5N/T5esr5ZfMmUDb0Y=,tag:nJPVTXgy+Ye6pKtqdnbJRQ==,type:str]",
-	"S3_BUCKET": "ENC[AES256_GCM,data:oIRqS3tkzzGlS2PFTZhsVLAvyPU=,iv:keirNKzqXRQrnr/my4kWrvewogN91dh1AEE0R2ajN90=,tag:Dq9qFoFB7CexpTLiwpSIfw==,type:str]",
+	"AWS_ACCESS_KEY_ID": "ENC[AES256_GCM,data:uqYreluUeb0Cq7W8YMRQNQHTxTI=,iv:gT5d8PuHZCUa/yQYM5hSEdxbSybwcHgZvAtaeF6YBUs=,tag:c5bIMv3M78oZNvy2UOmfGw==,type:str]",
+	"AWS_SECRET_ACCESS_KEY": "ENC[AES256_GCM,data:p7mFR05peGZqMnh2DFdWBa6NE1nuqw2CFuHRqNw4F/BSY/XpIc5sGw==,iv:eh/O+1osKPU/8obAxDU25zWVBDs5QqK1IjMiC9rAzSk=,tag:lcOI/jN5MDqtEl3DL1HYNQ==,type:str]",
+	"AWS_DEFAULT_REGION": "ENC[AES256_GCM,data:hObJI+PQU8Itz32m,iv:4kHOlBH+174fKlev4qJdjkSSPLmZQCwhn83rGFdc6ac=,tag:9exzOjZjutsBSflbt9aG2A==,type:str]",
+	"S3_BUCKET": "ENC[AES256_GCM,data:yDNCsFrKhNJHyRxY6AtpNBDWJY0=,iv:cKJcN/u1exYBztFixBvwqBZdOopRvlu1mPcNF1Gve6w=,tag:NImH34mNx0YTp6sgY74tqA==,type:str]",
 	"sops": {
 		"age": [
 			{
 				"recipient": "age1nv8y4wgg3zlj0f668tk5mhwe05fj5mw9rrqvr832h0gvmvq50ehs469ufn",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqT0xSb2N3R0R2RmZ2Qm9E\nOFZEUDRZUTRWM0J2VkUxbTFzdnBKWTNJVkJnCm50WW5RNUlUdVhFWnpqdHlpSVRB\nYk40RmFuQ0xxR3FkcE5ISnFSQ1pLMGcKLS0tIFY0ZDhQSXQwamllQjZVbEF2QkMz\nLy9ZcnlWMzFvcnJGd0Q2Z3pQMlQzQnMKUfk2HbgUG1smf1seiyRCnFiVeQAYKzWW\n0Oxek17VB5rmOEIfKCUpvjEgqLSVc4r8jWDJSOsi73KPbPYCbFpA/w==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjVW5veXovMUxIdnNtaVgv\nOC9QZUxDQ3hNYS9qRlNxRDZrclhzY21mUDFzClc2MG5XcWZGbVBqVWZZdmp5M3BM\nTm5icVM3NkVaOU0yZXJaSzdYbzlkUEkKLS0tIHRyemtuMHR0dkdZZ3pxLzNITlZI\ndG5kR3IxcjVYZFU0b0k1clVrTmRBQWMKcDhx96Lk2EtYqQDBjAHcwUVrF0QwWl31\na+qTwnt+6oLXQM5fpaPdoXOlBcK7hdTI1n9Gd3cOr1Yc11t4OapO/A==\n-----END AGE ENCRYPTED FILE-----\n"
 			},
 			{
 				"recipient": "age13gw838vly2a8nhvrtzs509zq5tzgpmqhvs0skp9n2jnzqg2qmscsy3utra",
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4ZW11Rm1XcGdwbWxudkJM\nU3BNL0tiQ1pJaVNXajREdlpNVFpHMmFaVWtZCm5zNGxwTUNSSVN0alhhR2k4YXp3\nSFRxdVpzN1BvdTdlSC91c1V1TkJnWEkKLS0tIDVoQlhHRnNJa3hiQnM2aGx0OWJC\ndk91dVVweUpGNEhXUXBSaTZsVGlmV0kK8tmSZB7rV6g3Y3l//k6ebZwQC+9vOpuX\nLGvNExgy0grHuHNi5O+5RphkOSYY3eMKTFkBX8HngXGek9eofo1sZA==\n-----END AGE ENCRYPTED FILE-----\n"
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoU3lRMndFMTJnZmhmbkFn\nNHp0Q3E4VkNiOUs3WkM2SEtZaWg2b1VBMVY0ClQ4cFFqSGlyamdZQm8zYkJBWGxW\nZkUxSWFUS2pBT1VLMXJSRlRXWFc0SGMKLS0tIHdnNGQrd0ltSkN1dHJydTVuTEFW\nNjIxREZJMUlLd09HUWthRWoyVGNDTXcKqFDDTLoBfK1LGiAOBheObabpUKHrIWEv\nzZd405/r1JT4cNMYY+GrPOyo2jAJQAhChcI5dAA5uaWTDiCrqPtSiA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-03-22T21:49:17Z",
-		"mac": "ENC[AES256_GCM,data:UOTPSSoRazamLtDesDOdLwtO0ALF3NIptvv3YvLONRByeV75LO+ziwLIqDYrnhYlgyLoOhqqrqCwWmWLLm2VHLMxK4ZDlBdzzn7ZoxSiB8vVKR5UmbLYv6EIDWTEX1tlBQFUoPJFffTa74rkOLA0Pe02XdZFqYL1eg4TZJjjhfs=,iv:EB8SOzlY0UqSkQneiYTvIGSa1EZwg8JIhDnDuogSDSc=,tag:7eB+ohnpgudZ+7SzCnWRRA==,type:str]",
+		"lastmodified": "2026-03-23T01:40:01Z",
+		"mac": "ENC[AES256_GCM,data:isIPkRxxghlrtjDzIKBuIxPh/AEXJy2wRergO3qvUjBNSAgaleFSGNz58zaCCUMwEwWcfNoLLAzs7+GVv6TVu2zDlViTXqN7FnyXcBhZQJRQ0hwYpGyVoxLMGgzfd7REii9CoTmCaetkCW8T/QpAiQDXfRPPi8iW3Sku5EfnA74=,iv:m9Tj+MT7RZxMdlaViWbbn3iklR5vnlp6UJKw8DStk+g=,tag:i/L1DX5wST4u63sKmovx7Q==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.12.2"
 	}

--- a/services/grafana/dashboards/coupette.json
+++ b/services/grafana/dashboards/coupette.json
@@ -6,7 +6,6 @@
   "version": 1,
   "timezone": "browser",
   "editable": true,
-  "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "refresh": "30s",
   "time": {
@@ -17,34 +16,20 @@
   "panels": [
     {
       "type": "row",
-      "title": "Backend",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
+      "title": "Health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
       "collapsed": false,
       "id": 1
     },
     {
       "type": "stat",
-      "title": "Backend Up",
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 1
-      },
+      "title": "Backend",
+      "gridPos": { "h": 5, "w": 3, "x": 0, "y": 1 },
       "id": 2,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
           "expr": "up{job=\"coupette-backend\"}",
-          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -54,28 +39,16 @@
             {
               "type": "value",
               "options": {
-                "0": {
-                  "text": "DOWN",
-                  "color": "red"
-                },
-                "1": {
-                  "text": "UP",
-                  "color": "green"
-                }
+                "0": { "text": "DOWN", "color": "red" },
+                "1": { "text": "UP", "color": "green" }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
             ]
           }
         }
@@ -85,27 +58,114 @@
         "graphMode": "none",
         "justifyMode": "center",
         "textMode": "value",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
+        "reduceOptions": { "calcs": ["lastNotNull"] }
       }
     },
     {
+      "type": "stat",
+      "title": "Request Rate",
+      "gridPos": { "h": 5, "w": 7, "x": 3, "y": 1 },
+      "id": 20,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"coupette-backend\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "p95 Latency",
+      "gridPos": { "h": 5, "w": 7, "x": 10, "y": 1 },
+      "id": 21,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"coupette-backend\"}[5m]))) * 1000",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 500 },
+              { "color": "red", "value": 2000 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Error Rate",
+      "gridPos": { "h": 5, "w": 7, "x": 17, "y": 1 },
+      "id": 22,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"coupette-backend\", status=\"5xx\"}[5m])) / sum(rate(http_requests_total{job=\"coupette-backend\"}[5m])) * 100",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "noValue": "0%",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "row",
+      "title": "Requests",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "collapsed": false,
+      "id": 30
+    },
+    {
       "type": "timeseries",
-      "title": "Request Rate by Handler",
-      "gridPos": {
-        "h": 8,
-        "w": 18,
-        "x": 6,
-        "y": 1
-      },
+      "title": "Rate by Handler",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 7 },
       "id": 3,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
           "expr": "sum by (handler) (rate(http_request_duration_seconds_count{job=\"coupette-backend\"}[5m]))",
@@ -118,183 +178,93 @@
           "unit": "reqps",
           "min": 0,
           "custom": {
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "lineWidth": 2,
             "spanNulls": false
           },
-          "color": {
-            "mode": "palette-classic"
-          }
+          "color": { "mode": "palette-classic" }
         }
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": ["mean", "max"]
-        }
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
       }
     },
     {
       "type": "timeseries",
       "title": "Latency p95 by Handler",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 9
-      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 7 },
       "id": 4,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, handler) (rate(http_request_duration_seconds_bucket{job=\"coupette-backend\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, handler) (rate(http_request_duration_seconds_bucket{job=\"coupette-backend\"}[5m]))) * 1000",
           "legendFormat": "{{ handler }}",
           "refId": "A"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "ms",
           "min": 0,
           "custom": {
             "fillOpacity": 0,
             "lineWidth": 2,
             "spanNulls": false
           },
-          "color": {
-            "mode": "palette-classic"
-          }
+          "color": { "mode": "palette-classic" }
         }
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": ["mean", "max"]
-        }
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "5xx Error Rate",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 9
-      },
-      "id": 5,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "sum by (handler) (rate(http_request_duration_seconds_count{job=\"coupette-backend\", status=~\"5..\"}[5m]))",
-          "legendFormat": "{{ handler }}",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
-          "min": 0,
-          "custom": {
-            "fillOpacity": 0,
-            "lineWidth": 2,
-            "spanNulls": false
-          },
-          "color": {
-            "mode": "palette-classic"
-          }
-        }
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": ["sum"]
-        }
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
       }
     },
     {
       "type": "row",
       "title": "Recommendations",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 17
-      },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
       "collapsed": false,
       "id": 6
     },
     {
       "type": "timeseries",
-      "title": "Recommendation Duration by Stage",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 18
-      },
+      "title": "Pipeline Duration by Stage",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
       "id": 7,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(coupette_recommendation_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(coupette_recommendation_duration_seconds_bucket[5m]))) * 1000",
           "legendFormat": "p95 {{ stage }}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum by (le, stage) (rate(coupette_recommendation_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le, stage) (rate(coupette_recommendation_duration_seconds_bucket[5m]))) * 1000",
           "legendFormat": "p50 {{ stage }}",
           "refId": "B"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "ms",
           "min": 0,
           "custom": {
             "fillOpacity": 0,
             "lineWidth": 2,
             "spanNulls": false
           },
-          "color": {
-            "mode": "palette-classic"
-          }
+          "color": { "mode": "palette-classic" }
         }
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": ["mean", "max"]
-        }
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
       }
     },
     {
       "type": "timeseries",
       "title": "Candidates per Recommendation",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 18
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
       "id": 8,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
           "expr": "histogram_quantile(0.95, sum by (le) (rate(coupette_recommendation_candidates_bucket[5m])))",
@@ -316,32 +286,53 @@
             "lineWidth": 2,
             "spanNulls": false
           },
-          "color": {
-            "mode": "palette-classic"
-          }
+          "color": { "mode": "palette-classic" }
         }
       },
       "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM Latency p95",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
+      "id": 11,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, service) (rate(coupette_llm_call_duration_seconds_bucket[5m]))) * 1000",
+          "legendFormat": "p95 {{ service }}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, service) (rate(coupette_llm_call_duration_seconds_bucket[5m]))) * 1000",
+          "legendFormat": "p50 {{ service }}",
+          "refId": "B"
         }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0,
+          "custom": {
+            "fillOpacity": 0,
+            "lineWidth": 2,
+            "spanNulls": false
+          },
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
       }
     },
     {
       "type": "piechart",
       "title": "Intent Classifications",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 26
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
       "id": 9,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
           "expr": "sum by (intent_type) (increase(coupette_intent_classifications_total[1h]))",
@@ -352,39 +343,21 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": {
-            "mode": "palette-classic"
-          }
+          "color": { "mode": "palette-classic" }
         }
       },
       "options": {
         "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": ["sum"]
-        }
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] }
       }
     },
     {
       "type": "timeseries",
       "title": "Token Usage",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 26
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
       "id": 10,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
           "expr": "sum by (service, direction) (rate(coupette_llm_tokens_total[5m]))",
@@ -397,95 +370,28 @@
           "unit": "short",
           "min": 0,
           "custom": {
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "lineWidth": 2,
             "spanNulls": false
           },
-          "color": {
-            "mode": "palette-classic"
-          }
+          "color": { "mode": "palette-classic" }
         }
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": ["mean", "max"]
-        }
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
       }
     },
     {
       "type": "timeseries",
-      "title": "LLM Call Latency p95",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 26
-      },
-      "id": 11,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.95, sum by (le, service) (rate(coupette_llm_call_duration_seconds_bucket[5m])))",
-          "legendFormat": "p95 {{ service }}",
-          "refId": "A"
-        },
-        {
-          "expr": "histogram_quantile(0.50, sum by (le, service) (rate(coupette_llm_call_duration_seconds_bucket[5m])))",
-          "legendFormat": "p50 {{ service }}",
-          "refId": "B"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "min": 0,
-          "custom": {
-            "fillOpacity": 0,
-            "lineWidth": 2,
-            "spanNulls": false
-          },
-          "color": {
-            "mode": "palette-classic"
-          }
-        }
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": ["mean", "max"]
-        }
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Errors",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 34
-      },
+      "title": "Pipeline Errors",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
       "id": 12,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (service) (rate(coupette_llm_errors_total[5m]))",
-          "legendFormat": "llm {{ service }}",
+          "expr": "sum by (error_type) (rate(coupette_recommendation_pipeline_errors_total[5m]))",
+          "legendFormat": "{{ error_type }}",
           "refId": "A"
-        },
-        {
-          "expr": "rate(coupette_recommendation_pipeline_errors_total[5m])",
-          "legendFormat": "pipeline",
-          "refId": "B"
         }
       ],
       "fieldConfig": {
@@ -493,21 +399,15 @@
           "unit": "short",
           "min": 0,
           "custom": {
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "lineWidth": 2,
             "spanNulls": false
           },
-          "color": {
-            "mode": "palette-classic"
-          }
+          "color": { "mode": "palette-classic" }
         }
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "calcs": ["sum"]
-        }
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] }
       }
     }
   ]

--- a/services/grafana/dashboards/platform-health.json
+++ b/services/grafana/dashboards/platform-health.json
@@ -1,7 +1,7 @@
 {
   "uid": "platform-health",
   "title": "Platform Health",
-  "description": "Scrape targets, container status, and host vitals",
+  "description": "At-a-glance health, container status, and traffic",
   "schemaVersion": 39,
   "version": 1,
   "timezone": "browser",
@@ -16,133 +16,20 @@
   "panels": [
     {
       "type": "row",
-      "title": "Availability",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
+      "title": "Health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
       "collapsed": false,
       "id": 1
     },
     {
-      "type": "table",
-      "title": "Scrape Targets",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 1
-      },
-      "id": 2,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "up",
-          "instant": true,
-          "format": "table",
-          "refId": "A"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "instance": true
-            },
-            "renameByName": {
-              "job": "Target",
-              "Value": "Status"
-            },
-            "indexByName": {
-              "job": 0,
-              "Value": 1
-            }
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto"
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Status"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "type": "value",
-                    "options": {
-                      "0": {
-                        "text": "DOWN",
-                        "color": "red"
-                      },
-                      "1": {
-                        "text": "UP",
-                        "color": "green"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": null
-                    },
-                    {
-                      "color": "green",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
       "type": "stat",
-      "title": "Containers Running / Expected",
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
-        "y": 1
-      },
+      "title": "Containers",
+      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 1 },
       "id": 3,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "count(container_last_seen{name!=\"\"} > (time() - 60))",
+          "expr": "count(container_last_seen{id!=\"/\"} > (time() - 120))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -152,18 +39,9 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 7
-              },
-              {
-                "color": "green",
-                "value": 8
-              }
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 9 },
+              { "color": "green", "value": 10 }
             ]
           },
           "unit": "none"
@@ -180,25 +58,146 @@
           "values": false
         }
       },
-      "description": "Expected: 8 infra containers. Red if any missing."
+      "description": "Running containers. Red if fewer than expected."
+    },
+    {
+      "type": "gauge",
+      "title": "CPU %",
+      "gridPos": { "h": 6, "w": 5, "x": 4, "y": 1 },
+      "id": 5,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Memory %",
+      "gridPos": { "h": 6, "w": 5, "x": 9, "y": 1 },
+      "id": 7,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "avg(100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 80 },
+              { "color": "red", "value": 95 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Disk %",
+      "gridPos": { "h": 6, "w": 5, "x": 14, "y": 1 },
+      "id": 8,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "max(100 - (node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} * 100))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 85 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Load Average",
+      "gridPos": { "h": 6, "w": 5, "x": 19, "y": 1 },
+      "id": 6,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "avg(node_load1)",
+          "legendFormat": "Load 1m",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(node_load5)",
+          "legendFormat": "Load 5m",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 2 },
+              { "color": "red", "value": 4 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name"
+      }
+    },
+    {
+      "type": "row",
+      "title": "Containers",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "collapsed": false,
+      "id": 15
     },
     {
       "type": "table",
       "title": "Container Details",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 1
-      },
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 8 },
       "id": 13,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "time() - container_last_seen{name!=\"\"}",
+          "expr": "time() - container_last_seen{id!=\"/\"}",
           "instant": true,
           "format": "table",
           "refId": "A"
@@ -230,21 +229,13 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": "auto"
-          }
+          "custom": { "align": "auto" }
         },
         "overrides": [
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Last Seen"
-            },
+            "matcher": { "id": "byName", "options": "Last Seen" },
             "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              },
+              { "id": "unit", "value": "s" },
               {
                 "id": "thresholds",
                 "value": {
@@ -267,236 +258,17 @@
     },
     {
       "type": "row",
-      "title": "Host Vitals",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 9
-      },
-      "collapsed": false,
-      "id": 4
-    },
-    {
-      "type": "gauge",
-      "title": "CPU %",
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 0,
-        "y": 10
-      },
-      "id": 5,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percent",
-          "min": 0,
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 70
-              },
-              {
-                "color": "red",
-                "value": 90
-              }
-            ]
-          }
-        },
-        "overrides": []
-      }
-    },
-    {
-      "type": "stat",
-      "title": "Load Average",
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 6,
-        "y": 10
-      },
-      "id": 6,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "node_load1",
-          "legendFormat": "1m",
-          "refId": "A"
-        },
-        {
-          "expr": "node_load5",
-          "legendFormat": "5m",
-          "refId": "B"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "decimals": 2,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 2
-              },
-              {
-                "color": "red",
-                "value": 4
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "value_and_name"
-      }
-    },
-    {
-      "type": "gauge",
-      "title": "Memory %",
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 12,
-        "y": 10
-      },
-      "id": 7,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percent",
-          "min": 0,
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 80
-              },
-              {
-                "color": "red",
-                "value": 95
-              }
-            ]
-          }
-        },
-        "overrides": []
-      }
-    },
-    {
-      "type": "gauge",
-      "title": "Disk %",
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 18,
-        "y": 10
-      },
-      "id": 8,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "100 - (node_filesystem_avail_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\", fstype!~\"tmpfs|overlay\"} * 100)",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percent",
-          "min": 0,
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 70
-              },
-              {
-                "color": "red",
-                "value": 85
-              }
-            ]
-          }
-        },
-        "overrides": []
-      }
-    },
-    {
-      "type": "row",
       "title": "Traffic",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 15
-      },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
       "collapsed": false,
       "id": 9
     },
     {
       "type": "stat",
       "title": "Request Rate",
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 0,
-        "y": 16
-      },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 14 },
       "id": 10,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
           "expr": "sum(rate(caddy_http_requests_total[5m]))",
@@ -510,14 +282,10 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
+              { "color": "green", "value": null }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "options": {
         "colorMode": "none",
@@ -526,47 +294,29 @@
     },
     {
       "type": "stat",
-      "title": "Caddy p95 Latency",
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 8,
-        "y": 16
-      },
+      "title": "p95 Latency",
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 14 },
       "id": 11,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(caddy_http_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(caddy_http_request_duration_seconds_bucket[5m]))) * 1000",
           "refId": "A"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "ms",
           "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.5
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 500 },
+              { "color": "red", "value": 1000 }
             ]
           }
-        },
-        "overrides": []
+        }
       },
       "options": {
         "colorMode": "value",
@@ -575,43 +325,179 @@
     },
     {
       "type": "stat",
-      "title": "VPS Uptime",
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 16,
-        "y": 16
-      },
-      "id": 12,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "title": "Error Rate",
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 14 },
+      "id": 14,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "time() - node_boot_time_seconds",
+          "expr": "sum(rate(caddy_http_requests_total{code=~\"[45].*\"}[5m])) / sum(rate(caddy_http_requests_total[5m])) * 100",
           "refId": "A"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "percent",
+          "decimals": 1,
+          "noValue": "0%",
           "thresholds": {
             "mode": "absolute",
             "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Network I/O",
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 14 },
+      "id": 17,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "avg(rate(node_network_receive_bytes_total{device!~\"lo|docker.*|br-.*|veth.*\"}[5m]))",
+          "legendFormat": "In",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(node_network_transmit_bytes_total{device!~\"lo|docker.*|br-.*|veth.*\"}[5m]))",
+          "legendFormat": "Out",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "min": 0,
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "spanNulls": false
+          },
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Internals",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 19 },
+      "collapsed": true,
+      "id": 16,
+      "panels": [
+        {
+          "type": "stat",
+          "title": "VPS Uptime",
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 20 },
+          "id": 12,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "max(time() - node_boot_time_seconds)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null }
+                ]
+              }
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none"
+          }
+        },
+        {
+          "type": "table",
+          "title": "Scrape Targets",
+          "gridPos": { "h": 8, "w": 18, "x": 6, "y": 20 },
+          "id": 2,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "up",
+              "instant": true,
+              "format": "table",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true,
+                  "instance": true
+                },
+                "renameByName": {
+                  "job": "Target",
+                  "Value": "Status"
+                },
+                "indexByName": {
+                  "job": 0,
+                  "Value": 1
+                }
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": { "align": "auto" }
+            },
+            "overrides": [
               {
-                "color": "green",
-                "value": null
+                "matcher": { "id": "byName", "options": "Status" },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "0": { "text": "DOWN", "color": "red" },
+                          "1": { "text": "UP", "color": "green" }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": { "type": "color-background" }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        { "color": "red", "value": null },
+                        { "color": "green", "value": 1 }
+                      ]
+                    }
+                  }
+                ]
               }
             ]
           }
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none"
-      }
+        }
+      ]
     }
   ]
 }

--- a/services/grafana/dashboards/postgres.json
+++ b/services/grafana/dashboards/postgres.json
@@ -1,7 +1,7 @@
 {
   "uid": "postgres",
   "title": "PostgreSQL",
-  "description": "Monitoring for shared-postgres (PostgreSQL 16 + pgvector)",
+  "description": "Connections, performance, and storage for shared-postgres",
   "schemaVersion": 39,
   "version": 1,
   "timezone": "browser",
@@ -12,23 +12,75 @@
     "from": "now-1h",
     "to": "now"
   },
+  "tags": ["postgresql", "database"],
   "panels": [
     {
       "type": "row",
-      "title": "Connections",
+      "title": "Health",
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
       "collapsed": false,
       "id": 1
     },
     {
       "type": "stat",
-      "title": "Active connections vs max",
-      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 1 },
-      "id": 2,
+      "title": "PostgreSQL",
+      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 1 },
+      "id": 40,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "pg_up",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "DOWN", "color": "red" },
+                "1": { "text": "UP", "color": "green" }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Connections",
+      "gridPos": { "h": 6, "w": 5, "x": 4, "y": 1 },
+      "id": 2,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(pg_stat_activity_count)",
+          "legendFormat": "Active",
+          "refId": "A"
+        },
+        {
+          "expr": "pg_settings_max_connections",
+          "legendFormat": "Max",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -42,79 +94,58 @@
         }
       },
       "options": {
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "orientation": "auto",
-        "textMode": "auto",
-        "wideLayout": true,
         "colorMode": "value",
         "graphMode": "area",
-        "justifyMode": "auto"
-      },
-      "targets": [
-        {
-          "expr": "sum(pg_stat_activity_count)",
-          "legendFormat": "Active",
-          "refId": "A"
-        },
-        {
-          "expr": "pg_settings_max_connections",
-          "legendFormat": "Max",
-          "refId": "B"
-        }
-      ]
+        "textMode": "value_and_name",
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" }
+      }
     },
     {
-      "type": "bargauge",
-      "title": "Connections by database",
-      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 1 },
-      "id": 3,
+      "type": "gauge",
+      "title": "Cache Hit Ratio",
+      "gridPos": { "h": 6, "w": 5, "x": 9, "y": 1 },
+      "id": 12,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(pg_stat_database_blks_hit{datname!~\"template.*|postgres\"}[5m])) / (sum(rate(pg_stat_database_blks_hit{datname!~\"template.*|postgres\"}[5m])) + sum(rate(pg_stat_database_blks_read{datname!~\"template.*|postgres\"}[5m])))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 20 },
-              { "color": "red", "value": 50 }
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.95 },
+              { "color": "green", "value": 0.99 }
             ]
           },
-          "unit": "none"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         }
       },
       "options": {
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "orientation": "horizontal",
-        "displayMode": "gradient",
-        "showUnfilled": true,
-        "minVizWidth": 8,
-        "minVizHeight": 16,
-        "namePlacement": "auto",
-        "valueMode": "color"
-      },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Database Sizes",
+      "gridPos": { "h": 6, "w": 10, "x": 14, "y": 1 },
+      "id": 31,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (datname) (pg_stat_activity_count)",
+          "expr": "pg_database_size_bytes{datname!~\"template.*|postgres\"}",
           "legendFormat": "{{datname}}",
           "refId": "A"
         }
-      ]
-    },
-    {
-      "type": "bargauge",
-      "title": "Connection state breakdown",
-      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 1 },
-      "id": 4,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      ],
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -122,38 +153,25 @@
             "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
-              { "color": "yellow", "value": 10 },
-              { "color": "red", "value": 30 }
+              { "color": "yellow", "value": 1073741824 },
+              { "color": "red", "value": 5368709120 }
             ]
           },
-          "unit": "none"
+          "unit": "bytes"
         }
       },
       "options": {
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
         "orientation": "horizontal",
         "displayMode": "gradient",
         "showUnfilled": true,
-        "minVizWidth": 8,
-        "minVizHeight": 16,
         "namePlacement": "auto",
         "valueMode": "color"
-      },
-      "targets": [
-        {
-          "expr": "sum by (state) (pg_stat_activity_count)",
-          "legendFormat": "{{state}}",
-          "refId": "A"
-        }
-      ]
+      }
     },
     {
       "type": "row",
-      "title": "Performance",
+      "title": "Activity",
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
       "collapsed": false,
       "id": 10
@@ -168,7 +186,7 @@
         "defaults": {
           "color": { "mode": "palette-classic" },
           "custom": {
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "lineWidth": 2,
             "lineInterpolation": "smooth",
             "showPoints": "never",
@@ -190,274 +208,47 @@
       ]
     },
     {
-      "type": "gauge",
-      "title": "Cache hit ratio",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
-      "id": 12,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 0.95 },
-              { "color": "green", "value": 0.99 }
-            ]
-          },
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1
-        }
-      },
-      "options": {
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "orientation": "auto",
-        "sizing": "auto"
-      },
-      "targets": [
-        {
-          "expr": "sum by (datname) (rate(pg_stat_database_blks_hit{datname!~\"template.*|postgres\"}[5m])) / (sum by (datname) (rate(pg_stat_database_blks_hit{datname!~\"template.*|postgres\"}[5m])) + sum by (datname) (rate(pg_stat_database_blks_read{datname!~\"template.*|postgres\"}[5m])))",
-          "legendFormat": "{{datname}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "gauge",
-      "title": "Index hit ratio",
-      "description": "Fraction of index reads served from cache vs disk. Below 0.99 with pgvector means index scans are hitting disk — check shared_buffers or index size.",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
-      "id": 14,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 0.95 },
-              { "color": "green", "value": 0.99 }
-            ]
-          },
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1
-        }
-      },
-      "options": {
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "orientation": "auto",
-        "sizing": "auto"
-      },
-      "targets": [
-        {
-          "expr": "sum(pg_stat_user_indexes_idx_blks_hit) / (sum(pg_stat_user_indexes_idx_blks_hit) + sum(pg_stat_user_indexes_idx_blks_read))",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "row",
-      "title": "Table Health",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
-      "collapsed": false,
-      "id": 20
-    },
-    {
-      "type": "bargauge",
-      "title": "Dead tuples by table",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 17 },
-      "id": 21,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1000 },
-              { "color": "red", "value": 10000 }
-            ]
-          },
-          "unit": "none"
-        }
-      },
-      "options": {
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "orientation": "horizontal",
-        "displayMode": "gradient",
-        "showUnfilled": true,
-        "minVizWidth": 8,
-        "minVizHeight": 16,
-        "namePlacement": "auto",
-        "valueMode": "color"
-      },
-      "targets": [
-        {
-          "expr": "topk(10, pg_stat_user_tables_n_dead_tup)",
-          "legendFormat": "{{relname}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "bargauge",
-      "title": "Table sizes",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 17 },
-      "id": 22,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 104857600 },
-              { "color": "red", "value": 1073741824 }
-            ]
-          },
-          "unit": "bytes"
-        }
-      },
-      "options": {
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "orientation": "horizontal",
-        "displayMode": "gradient",
-        "showUnfilled": true,
-        "minVizWidth": 8,
-        "minVizHeight": 16,
-        "namePlacement": "auto",
-        "valueMode": "color"
-      },
-      "targets": [
-        {
-          "expr": "topk(10, pg_total_relation_size_bytes)",
-          "legendFormat": "{{relname}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "table",
-      "title": "Last autovacuum",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 17 },
-      "id": 23,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null }
-            ]
-          },
-          "unit": "dateTimeAsIso",
-          "custom": {
-            "align": "auto",
-            "cellOptions": { "type": "auto" },
-            "inspect": false
-          }
-        },
-        "overrides": [
-          {
-            "matcher": { "id": "byName", "options": "relname" },
-            "properties": [
-              { "id": "custom.width", "value": 200 }
-            ]
-          },
-          {
-            "matcher": { "id": "byName", "options": "Time" },
-            "properties": [
-              { "id": "custom.hidden", "value": true }
-            ]
-          }
-        ]
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "footer": { "show": false, "reducer": ["sum"], "countRows": false }
-      },
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": ["lastNotNull"],
-            "labelsToFields": true
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "__name__": true,
-              "instance": true,
-              "job": true,
-              "schemaname": true,
-              "server": true
-            },
-            "renameByName": {
-              "relname": "Table",
-              "Last *": "Last Autovacuum"
-            }
-          }
-        }
-      ],
-      "targets": [
-        {
-          "expr": "pg_stat_user_tables_last_autovacuum",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "row",
-      "title": "Database Size",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 },
-      "collapsed": false,
-      "id": 30
-    },
-    {
       "type": "timeseries",
-      "title": "Database size over time",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
-      "id": 31,
+      "title": "Connections by state",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
+      "id": 4,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
           "custom": {
-            "fillOpacity": 0,
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "lineInterpolation": "smooth",
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "none"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (state) (pg_stat_activity_count{state!=\"\"})",
+          "legendFormat": "{{state}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Database size over time",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
+      "id": 32,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 10,
             "lineWidth": 2,
             "lineInterpolation": "smooth",
             "showPoints": "never",
@@ -477,89 +268,6 @@
           "refId": "A"
         }
       ]
-    },
-    {
-      "type": "stat",
-      "title": "saq_sommelier size",
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 26 },
-      "id": 32,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1073741824 },
-              { "color": "red", "value": 5368709120 }
-            ]
-          },
-          "unit": "bytes"
-        }
-      },
-      "options": {
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "orientation": "auto",
-        "textMode": "auto",
-        "wideLayout": true,
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto"
-      },
-      "targets": [
-        {
-          "expr": "pg_database_size_bytes{datname=\"saq_sommelier\"}",
-          "legendFormat": "saq_sommelier",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "umami size",
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 26 },
-      "id": 33,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1073741824 },
-              { "color": "red", "value": 5368709120 }
-            ]
-          },
-          "unit": "bytes"
-        }
-      },
-      "options": {
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "orientation": "auto",
-        "textMode": "auto",
-        "wideLayout": true,
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto"
-      },
-      "targets": [
-        {
-          "expr": "pg_database_size_bytes{datname=\"umami\"}",
-          "legendFormat": "umami",
-          "refId": "A"
-        }
-      ]
     }
-  ],
-  "tags": ["postgresql", "database"]
+  ]
 }

--- a/systemd/pg-backup.service
+++ b/systemd/pg-backup.service
@@ -5,6 +5,8 @@ Requires=docker.service
 
 [Service]
 Type=oneshot
+Nice=19
+IOSchedulingClass=idle
 EnvironmentFile=/home/deploy/infra/secrets/aws-infra-backup.env
 EnvironmentFile=/home/deploy/infra/secrets/monitor-backups.env
 ExecStart=/home/deploy/infra/scripts/postgres_backup.sh


### PR DESCRIPTION
## Summary

- All 3 Grafana dashboards reworked — health-first layout, fixed broken queries, removed panels with non-existent metrics
- cAdvisor fix: mount containerd socket so per-container metrics are emitted
- Backup hardening: Nice=19 + IOSchedulingClass=idle for CPU courtesy, re-encrypted AWS credentials
- Makefile: `create-secret` and `edit-secret` targets for sops workflow

## Changes

### Dashboards
- **platform-health.json** — health row (containers + gauges + load avg), container details full-width, traffic row (+ error rate + network I/O), scrape targets moved to collapsed Internals row. Fixed stale series with `avg()`/`max()` aggregation. Latency in ms.
- **postgres.json** — added PG Up indicator, DB sizes as bar gauge (auto-scales). Removed 4 broken panels (index hit ratio, table sizes, dead tuples, autovacuum — metrics don't exist in Alloy's postgres exporter). Connections by state as timeseries.
- **coupette.json** — health row with summary stats (up, rate, latency, error rate). Fixed 5xx query (`http_requests_total` not `http_request_duration_seconds_count`). Removed non-existent `coupette_llm_errors_total`. All latency in ms.

### Infrastructure
- `docker-compose.yml` — added containerd socket mount for cAdvisor, removed redundant cgroup mount, cleaned up volume comments
- `systemd/pg-backup.service` — Nice=19 + IOSchedulingClass=idle (low CPU priority for backups)
- `secrets/aws-infra-backup.env.enc` — re-encrypted with real credentials (was placeholder)
- `Makefile` — `create-secret` and `edit-secret` targets with safe error handling

## Deploy notes

After merge + CD:
1. Alloy will restart with containerd socket — check container metrics appear:
   ```
   docker logs alloy 2>&1 | grep cadvisor | tail -5
   ```
2. Verify dashboards load correctly in Grafana
3. Container Details panel should populate (if cAdvisor now sees containers)
4. If container panels still empty: flip `store_container_labels = true` in Alloy config