### PR TITLE
fix: dashboard UX rework, cAdvisor labels, Prometheus 30d retention, and LLM cost tracking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
-      - "--storage.tsdb.retention.time=7d"
+      - "--storage.tsdb.retention.time=30d"
       - "--web.enable-remote-write-receiver"
     volumes:
       - ./services/prometheus:/etc/prometheus:ro

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,8 +92,8 @@ Coupette's RAG pipeline needs structured metrics and log aggregation. `docker lo
 
 ### Backup strategy
 
-- [ ] Daily Postgres dumps (all DBs) → AWS S3 — 30-day retention via S3 lifecycle rule
-- [ ] Backup script rewritten — S3 as primary (no local retention), fail loudly on upload failure
+- [x] Daily Postgres dumps (all DBs) → AWS S3 — 30-day retention via S3 lifecycle rule
+- [x] Backup script rewritten — S3 as primary (no local retention), fail loudly on upload failure
 - [ ] Restore smoke test — verify current dumps restore into a throwaway container before trusting offsite
 
 ### Terraform
@@ -189,6 +189,7 @@ Concrete housekeeping — not phased, ship when convenient.
 
 ## Ideas (unscoped)
 
+- [ ] Coupette analytics dashboard — intent distribution, user engagement, search patterns (separate from ops dashboards)
 - [ ] Staging environment — same VPS, separate ports + DB, promotion pattern
 - [ ] Multi-node — second VPS, load balancing (only if traffic demands)
 - [ ] HashiCorp Vault — centralized secrets with RBAC (overkill until team grows)

--- a/services/alloy/config.alloy
+++ b/services/alloy/config.alloy
@@ -61,7 +61,7 @@ prometheus.scrape "node" {
 prometheus.exporter.cadvisor "containers" {
   docker_host  = "unix:///var/run/docker.sock"
   docker_only  = true
-  store_container_labels = false
+  store_container_labels = true
 }
 
 prometheus.scrape "cadvisor" {

--- a/services/grafana/dashboards/coupette.json
+++ b/services/grafana/dashboards/coupette.json
@@ -64,7 +64,7 @@
     {
       "type": "stat",
       "title": "Request Rate",
-      "gridPos": { "h": 5, "w": 7, "x": 3, "y": 1 },
+      "gridPos": { "h": 5, "w": 5, "x": 3, "y": 1 },
       "id": 20,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
@@ -92,8 +92,39 @@
     },
     {
       "type": "stat",
+      "title": "p50 Latency",
+      "gridPos": { "h": 5, "w": 5, "x": 8, "y": 1 },
+      "id": 23,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"coupette-backend\"}[5m]))) * 1000",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 200 },
+              { "color": "red", "value": 500 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
       "title": "p95 Latency",
-      "gridPos": { "h": 5, "w": 7, "x": 10, "y": 1 },
+      "gridPos": { "h": 5, "w": 5, "x": 13, "y": 1 },
       "id": 21,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
@@ -123,8 +154,8 @@
     },
     {
       "type": "stat",
-      "title": "Error Rate",
-      "gridPos": { "h": 5, "w": 7, "x": 17, "y": 1 },
+      "title": "5xx Error Rate",
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 1 },
       "id": 22,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
@@ -168,7 +199,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (handler) (rate(http_request_duration_seconds_count{job=\"coupette-backend\"}[5m]))",
+          "expr": "topk(5, sum by (handler) (rate(http_request_duration_seconds_count{job=\"coupette-backend\"}[5m])))",
           "legendFormat": "{{ handler }}",
           "refId": "A"
         }
@@ -178,7 +209,7 @@
           "unit": "reqps",
           "min": 0,
           "custom": {
-            "fillOpacity": 10,
+            "fillOpacity": 0,
             "lineWidth": 2,
             "spanNulls": false
           },
@@ -186,7 +217,7 @@
         }
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+        "legend": { "displayMode": "list", "placement": "bottom" }
       }
     },
     {
@@ -197,7 +228,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, handler) (rate(http_request_duration_seconds_bucket{job=\"coupette-backend\"}[5m]))) * 1000",
+          "expr": "topk(5, histogram_quantile(0.95, sum by (le, handler) (rate(http_request_duration_seconds_bucket{job=\"coupette-backend\"}[5m]))) * 1000)",
           "legendFormat": "{{ handler }}",
           "refId": "A"
         }
@@ -215,66 +246,222 @@
         }
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Search",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "collapsed": false,
+      "id": 40
+    },
+    {
+      "type": "stat",
+      "title": "Search Rate",
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 16 },
+      "id": 41,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_request_duration_seconds_count{job=\"coupette-backend\", handler=\"/api/products\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Search p95",
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 16 },
+      "id": 42,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"coupette-backend\", handler=\"/api/products\"}[5m]))) * 1000",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 500 },
+              { "color": "red", "value": 1000 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Facets p95",
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 16 },
+      "id": 44,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"coupette-backend\", handler=\"/api/products/facets\"}[5m]))) * 1000",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 500 },
+              { "color": "red", "value": 1000 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area"
       }
     },
     {
       "type": "row",
       "title": "Recommendations",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
       "collapsed": false,
       "id": 6
     },
     {
-      "type": "timeseries",
-      "title": "Pipeline Duration by Stage",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+      "type": "bargauge",
+      "title": "Chat Latency p95",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 23 },
       "id": 7,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(coupette_recommendation_duration_seconds_bucket[5m]))) * 1000",
-          "legendFormat": "p95 {{ stage }}",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(coupette_recommendation_duration_seconds_bucket{stage=\"retrieval\"}[5m]))) * 1000",
+          "legendFormat": "Semantic Search",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum by (le, stage) (rate(coupette_recommendation_duration_seconds_bucket[5m]))) * 1000",
-          "legendFormat": "p50 {{ stage }}",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(coupette_recommendation_duration_seconds_bucket{stage=\"embed\"}[5m]))) * 1000",
+          "legendFormat": "Query Embedding",
           "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(coupette_recommendation_duration_seconds_bucket{stage=\"llm\"}[5m]))) * 1000",
+          "legendFormat": "Claude Calls",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(coupette_recommendation_duration_seconds_bucket{stage=\"total\"}[5m]))) * 1000",
+          "legendFormat": "Total",
+          "refId": "D"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "ms",
           "min": 0,
-          "custom": {
-            "fillOpacity": 0,
-            "lineWidth": 2,
-            "spanNulls": false
-          },
-          "color": { "mode": "palette-classic" }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5000 },
+              { "color": "red", "value": 10000 }
+            ]
+          }
         }
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "namePlacement": "auto",
+        "valueMode": "color"
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Claude Calls p95",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 23 },
+      "id": 11,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(coupette_llm_call_duration_seconds_bucket{service=\"intent\"}[5m]))) * 1000",
+          "legendFormat": "Intent Classification",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(coupette_llm_call_duration_seconds_bucket{service=\"curation\"}[5m]))) * 1000",
+          "legendFormat": "Wine Curation",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(coupette_llm_call_duration_seconds_bucket{service=\"sommelier\"}[5m]))) * 1000",
+          "legendFormat": "Sommelier Chat",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 3000 },
+              { "color": "red", "value": 5000 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "namePlacement": "auto",
+        "valueMode": "color"
       }
     },
     {
       "type": "timeseries",
-      "title": "Candidates per Recommendation",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
-      "id": 8,
+      "title": "Pipeline Errors",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 23 },
+      "id": 12,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(coupette_recommendation_candidates_bucket[5m])))",
-          "legendFormat": "p95",
+          "expr": "sum by (error_type) (rate(coupette_recommendation_pipeline_errors_total[5m]))",
+          "legendFormat": "{{ error_type }}",
           "refId": "A"
-        },
-        {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(coupette_recommendation_candidates_bucket[5m])))",
-          "legendFormat": "p50",
-          "refId": "B"
         }
       ],
       "fieldConfig": {
@@ -294,120 +481,115 @@
       }
     },
     {
-      "type": "timeseries",
-      "title": "LLM Latency p95",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
-      "id": 11,
+      "type": "row",
+      "title": "Costs",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 },
+      "collapsed": false,
+      "id": 50
+    },
+    {
+      "type": "stat",
+      "title": "Claude Tokens (30d)",
+      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 32 },
+      "id": 51,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, service) (rate(coupette_llm_call_duration_seconds_bucket[5m]))) * 1000",
-          "legendFormat": "p95 {{ service }}",
+          "expr": "sum(increase(coupette_llm_tokens_total{direction=\"in\"}[30d]))",
+          "legendFormat": "Input",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum by (le, service) (rate(coupette_llm_call_duration_seconds_bucket[5m]))) * 1000",
-          "legendFormat": "p50 {{ service }}",
+          "expr": "sum(increase(coupette_llm_tokens_total{direction=\"out\"}[30d]))",
+          "legendFormat": "Output",
           "refId": "B"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "ms",
-          "min": 0,
-          "custom": {
-            "fillOpacity": 0,
-            "lineWidth": 2,
-            "spanNulls": false
-          },
-          "color": { "mode": "palette-classic" }
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
         }
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
+        "colorMode": "none",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
       }
     },
     {
-      "type": "piechart",
-      "title": "Intent Classifications",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
-      "id": 9,
+      "type": "stat",
+      "title": "Claude Cost (30d)",
+      "description": "Haiku 4.5 — $1/MTok in, $5/MTok out",
+      "gridPos": { "h": 6, "w": 4, "x": 4, "y": 32 },
+      "id": 52,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (intent_type) (increase(coupette_intent_classifications_total[1h]))",
-          "legendFormat": "{{ intent_type }}",
+          "expr": "(sum(increase(coupette_llm_tokens_total{direction=\"in\"}[30d])) / 1000000 * 1) + (sum(increase(coupette_llm_tokens_total{direction=\"out\"}[30d])) / 1000000 * 5)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Tokens by Service (30d)",
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 32 },
+      "id": 53,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (service) (increase(coupette_llm_tokens_total[30d]))",
+          "legendFormat": "{{ service }}",
           "refId": "A"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": { "mode": "palette-classic" }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
         }
       },
       "options": {
-        "pieType": "donut",
-        "reduceOptions": { "calcs": ["lastNotNull"] },
-        "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] }
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Token Usage",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
-      "id": 10,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "targets": [
-        {
-          "expr": "sum by (service, direction) (rate(coupette_llm_tokens_total[5m]))",
-          "legendFormat": "{{ service }} {{ direction }}",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "min": 0,
-          "custom": {
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "spanNulls": false
-          },
-          "color": { "mode": "palette-classic" }
-        }
-      },
-      "options": {
-        "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] }
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Pipeline Errors",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
-      "id": 12,
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "targets": [
-        {
-          "expr": "sum by (error_type) (rate(coupette_recommendation_pipeline_errors_total[5m]))",
-          "legendFormat": "{{ error_type }}",
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "min": 0,
-          "custom": {
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "spanNulls": false
-          },
-          "color": { "mode": "palette-classic" }
-        }
-      },
-      "options": {
-        "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] }
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "namePlacement": "auto",
+        "valueMode": "color"
       }
     }
   ]

--- a/services/grafana/dashboards/platform-health.json
+++ b/services/grafana/dashboards/platform-health.json
@@ -24,7 +24,7 @@
     {
       "type": "stat",
       "title": "Containers",
-      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 1 },
+      "gridPos": { "h": 3, "w": 4, "x": 0, "y": 1 },
       "id": 3,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
@@ -59,6 +59,45 @@
         }
       },
       "description": "Running containers. Red if fewer than expected."
+    },
+    {
+      "type": "stat",
+      "title": "Observability",
+      "gridPos": { "h": 3, "w": 4, "x": 0, "y": 4 },
+      "id": 18,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "count(up == 1)",
+          "legendFormat": "up",
+          "refId": "A"
+        },
+        {
+          "expr": "count(up)",
+          "legendFormat": "total",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 8 }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "description": "Scrape targets reporting UP. Expand Internals to see details."
     },
     {
       "type": "gauge",
@@ -325,13 +364,13 @@
     },
     {
       "type": "stat",
-      "title": "Error Rate",
+      "title": "5xx Error Rate",
       "gridPos": { "h": 5, "w": 6, "x": 12, "y": 14 },
       "id": 14,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum(rate(caddy_http_requests_total{code=~\"[45].*\"}[5m])) / sum(rate(caddy_http_requests_total[5m])) * 100",
+          "expr": "sum(rate(caddy_http_requests_total{code=~\"5.*\"}[5m])) / sum(rate(caddy_http_requests_total[5m])) * 100",
           "refId": "A"
         }
       ],
@@ -378,7 +417,7 @@
           "unit": "Bps",
           "min": 0,
           "custom": {
-            "fillOpacity": 10,
+            "fillOpacity": 0,
             "lineWidth": 1,
             "spanNulls": false
           },
@@ -399,7 +438,7 @@
         {
           "type": "stat",
           "title": "VPS Uptime",
-          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 20 },
+          "gridPos": { "h": 3, "w": 4, "x": 0, "y": 20 },
           "id": 12,
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
@@ -427,7 +466,7 @@
         {
           "type": "table",
           "title": "Scrape Targets",
-          "gridPos": { "h": 8, "w": 18, "x": 6, "y": 20 },
+          "gridPos": { "h": 6, "w": 12, "x": 4, "y": 20 },
           "id": 2,
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
@@ -463,6 +502,19 @@
               "custom": { "align": "auto" }
             },
             "overrides": [
+              {
+                "matcher": { "id": "byName", "options": "Target" },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      { "type": "value", "options": { "integrations/unix": { "text": "Node Exporter" } } },
+                      { "type": "value", "options": { "integrations/cadvisor": { "text": "cAdvisor" } } },
+                      { "type": "value", "options": { "integrations/postgres": { "text": "Postgres Exporter" } } }
+                    ]
+                  }
+                ]
+              },
               {
                 "matcher": { "id": "byName", "options": "Status" },
                 "properties": [

--- a/services/grafana/dashboards/postgres.json
+++ b/services/grafana/dashboards/postgres.json
@@ -9,7 +9,7 @@
   "graphTooltip": 1,
   "refresh": "30s",
   "time": {
-    "from": "now-1h",
+    "from": "now-30d",
     "to": "now"
   },
   "tags": ["postgresql", "database"],
@@ -24,7 +24,7 @@
     {
       "type": "stat",
       "title": "PostgreSQL",
-      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 1 },
+      "gridPos": { "h": 6, "w": 3, "x": 0, "y": 1 },
       "id": 40,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
@@ -64,7 +64,7 @@
     {
       "type": "stat",
       "title": "Connections",
-      "gridPos": { "h": 6, "w": 5, "x": 4, "y": 1 },
+      "gridPos": { "h": 6, "w": 4, "x": 3, "y": 1 },
       "id": 2,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
@@ -103,13 +103,12 @@
     {
       "type": "gauge",
       "title": "Cache Hit Ratio",
-      "gridPos": { "h": 6, "w": 5, "x": 9, "y": 1 },
+      "gridPos": { "h": 6, "w": 4, "x": 7, "y": 1 },
       "id": 12,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
           "expr": "sum(rate(pg_stat_database_blks_hit{datname!~\"template.*|postgres\"}[5m])) / (sum(rate(pg_stat_database_blks_hit{datname!~\"template.*|postgres\"}[5m])) + sum(rate(pg_stat_database_blks_read{datname!~\"template.*|postgres\"}[5m])))",
-          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -134,9 +133,79 @@
       }
     },
     {
-      "type": "bargauge",
+      "type": "stat",
+      "title": "Deadlocks",
+      "description": "Deadlocks in the last hour. Should always be 0.",
+      "gridPos": { "h": 6, "w": 3, "x": 11, "y": 1 },
+      "id": 50,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(increase(pg_stat_database_deadlocks{datname!~\"template.*|postgres\"}[1h]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Longest Tx",
+      "description": "Longest running transaction in seconds. Red if stuck > 60s.",
+      "gridPos": { "h": 6, "w": 3, "x": 14, "y": 1 },
+      "id": 51,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "max(pg_stat_activity_max_tx_duration)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 60 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
       "title": "Database Sizes",
-      "gridPos": { "h": 6, "w": 10, "x": 14, "y": 1 },
+      "gridPos": { "h": 6, "w": 7, "x": 17, "y": 1 },
       "id": 31,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
@@ -148,7 +217,6 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -161,12 +229,10 @@
         }
       },
       "options": {
-        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
-        "orientation": "horizontal",
-        "displayMode": "gradient",
-        "showUnfilled": true,
-        "namePlacement": "auto",
-        "valueMode": "color"
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" }
       }
     },
     {
@@ -179,14 +245,14 @@
     {
       "type": "timeseries",
       "title": "Transactions per second",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "id": 11,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
           "custom": {
-            "fillOpacity": 10,
+            "fillOpacity": 0,
             "lineWidth": 2,
             "lineInterpolation": "smooth",
             "showPoints": "never",
@@ -210,14 +276,14 @@
     {
       "type": "timeseries",
       "title": "Connections by state",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
       "id": 4,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
           "custom": {
-            "fillOpacity": 10,
+            "fillOpacity": 0,
             "lineWidth": 2,
             "lineInterpolation": "smooth",
             "showPoints": "never",
@@ -241,14 +307,14 @@
     {
       "type": "timeseries",
       "title": "Database size over time",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
       "id": 32,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
           "custom": {
-            "fillOpacity": 10,
+            "fillOpacity": 0,
             "lineWidth": 2,
             "lineInterpolation": "smooth",
             "showPoints": "never",


### PR DESCRIPTION
## Summary

- All 3 dashboards reworked for UX: health-first layout, readable legends, human-friendly names
- cAdvisor: `store_container_labels = true` to emit per-container metrics with `name` labels
- Prometheus retention extended from 7d to 30d
- Coupette: added Search row, Costs row (Claude tokens + cost + per-service breakdown), LLM cost tracking
- Postgres: added Deadlocks + Longest Tx panels, default 30d time range
- Platform Health: Observability stat in health row, scrape targets with friendly names, Network I/O panel

## Changes

- `docker-compose.yml` — Prometheus retention 7d → 30d
- `services/alloy/config.alloy` — `store_container_labels = true`
- `services/grafana/dashboards/platform-health.json` — Observability stat, 5xx-only error rate, Network I/O, scrape targets with relabeled `integrations/*` names, VPS Uptime in Internals
- `services/grafana/dashboards/postgres.json` — Deadlocks stat, Longest Tx stat, DB sizes as stat, default 30d, DB size over time full-width
- `services/grafana/dashboards/coupette.json` — p50 Latency in health row, Search row (rate + p95 + facets p95), bar gauges for pipeline/LLM latency with human names, Costs row (Claude tokens in/out, cost, per-service breakdown), removed Intent Classifications pie, top-5 handlers, all legends bottom, fillOpacity 0
- `docs/ROADMAP.md` — added coupette analytics dashboard to Ideas, marked backup items complete

## Deploy notes

After merge + CD:
1. Prometheus will restart with 30d retention — no data loss, just extends window
2. Alloy will restart with `store_container_labels = true` — check container metrics:
   ```
   docker exec prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=container_cpu_usage_seconds_total{id!="/"}' | python3 -c "import json,sys; print(len(json.load(sys.stdin)['data']['result']))"
   ```
3. If container metrics still empty: Alloy's embedded cAdvisor may need further debugging (standalone cAdvisor container as fallback)
4. Clean up test container if still running: `docker rm -f cadvisor-test`