### PR TITLE
feat: standalone cAdvisor, Logs dashboard, and dashboard cross-links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 up: ## Start local dev stack (excludes postgres + umami, see #70)
-	$(COMPOSE) up -d caddy uptime-kuma umami alloy grafana shared-postgres
+	$(COMPOSE) up -d caddy uptime-kuma umami alloy grafana shared-postgres cadvisor
 
 down: ## Stop local dev stack
 	$(COMPOSE) down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,6 +153,29 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.51.0
+    container_name: cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+    command:
+      - "--docker_only=true"
+      - "--housekeeping_interval=15s"
+      - "--disable_metrics=advtcp,cpu_topology,cpuset,hugetlb,memory_numa,process,referenced_memory,resctrl,sched,tcp,udp"
+    networks:
+      - internal
+    read_only: true
+    security_opt: [no-new-privileges:true]
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   alloy:
     image: grafana/alloy:v1.14.1
     container_name: alloy
@@ -166,7 +189,7 @@ services:
     volumes:
       - ./services/alloy:/etc/alloy:ro
       - alloy_data:/var/lib/alloy/data
-      # loki.source.docker + cadvisor: container log tailing + container discovery
+      # loki.source.docker: container log tailing
       - /var/run/docker.sock:/var/run/docker.sock:ro
       # loki.source.journal: systemd timer/service logs
       - /var/log/journal:/var/log/journal:ro
@@ -176,10 +199,6 @@ services:
       - /sys:/host/sys:ro
       # node_exporter (rootfs_path): disk capacity, usage, inodes
       - /:/host/root:ro
-      # cadvisor: container metadata, overlay filesystem info
-      - /var/lib/docker:/var/lib/docker:ro
-      # cadvisor: containerd runtime socket for per-container metrics
-      - /run/containerd/containerd.sock:/run/containerd/containerd.sock:ro
     depends_on:
       loki:
         condition: service_started

--- a/services/alloy/config.alloy
+++ b/services/alloy/config.alloy
@@ -55,22 +55,6 @@ prometheus.scrape "node" {
 }
 
 // =============================================================================
-// Container metrics (per-container CPU, memory, network, disk I/O)
-// =============================================================================
-
-prometheus.exporter.cadvisor "containers" {
-  docker_host  = "unix:///var/run/docker.sock"
-  docker_only  = true
-  store_container_labels = true
-}
-
-prometheus.scrape "cadvisor" {
-  targets         = prometheus.exporter.cadvisor.containers.targets
-  forward_to      = [prometheus.remote_write.default.receiver]
-  scrape_interval = "15s"
-}
-
-// =============================================================================
 // PostgreSQL metrics (connections, query latency, table sizes, dead tuples)
 // =============================================================================
 

--- a/services/grafana/dashboards/coupette.json
+++ b/services/grafana/dashboards/coupette.json
@@ -13,6 +13,11 @@
     "to": "now"
   },
   "tags": ["coupette", "app"],
+  "links": [
+    { "title": "Platform Health", "url": "/d/platform-health", "type": "link", "icon": "dashboard" },
+    { "title": "PostgreSQL", "url": "/d/postgres", "type": "link", "icon": "database" },
+    { "title": "Logs", "url": "/d/logs", "type": "link", "icon": "document-info" }
+  ],
   "panels": [
     {
       "type": "row",

--- a/services/grafana/dashboards/logs.json
+++ b/services/grafana/dashboards/logs.json
@@ -1,0 +1,137 @@
+{
+  "uid": "logs",
+  "title": "Logs",
+  "description": "Container and systemd logs via Loki",
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "tags": ["logs"],
+  "links": [
+    { "title": "Platform Health", "url": "/d/platform-health", "type": "link", "icon": "dashboard" },
+    { "title": "PostgreSQL", "url": "/d/postgres", "type": "link", "icon": "database" },
+    { "title": "Coupette", "url": "/d/coupette", "type": "link", "icon": "apps" }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "container",
+        "label": "Container",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": { "label": "container", "stream": "", "type": 1 },
+        "current": { "text": "All", "value": "$__all" },
+        "includeAll": true,
+        "allValue": ".+",
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "search",
+        "label": "Search",
+        "type": "textbox",
+        "current": { "text": "", "value": "" }
+      },
+      {
+        "name": "level",
+        "label": "Level",
+        "type": "custom",
+        "current": { "text": "All", "value": "" },
+        "options": [
+          { "text": "All", "value": "", "selected": true },
+          { "text": "Error", "value": "error|fatal" },
+          { "text": "Warn", "value": "warn" },
+          { "text": "Info", "value": "info" }
+        ],
+        "query": "error,warn,info"
+      },
+      {
+        "name": "job",
+        "label": "Job",
+        "type": "custom",
+        "current": { "text": "All", "value": "$__all" },
+        "includeAll": true,
+        "allValue": "pg-backup.*|disk-alert.*|coupette-.*",
+        "options": [
+          { "text": "All", "value": "$__all", "selected": true },
+          { "text": "Backup", "value": "pg-backup.*" },
+          { "text": "Disk Alert", "value": "disk-alert.*" },
+          { "text": "Scraper", "value": "coupette-scraper.*" },
+          { "text": "Availability", "value": "coupette-availability.*" }
+        ],
+        "query": "pg-backup.*,disk-alert.*,coupette-scraper.*,coupette-availability.*"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Container Logs",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "id": 1
+    },
+    {
+      "type": "logs",
+      "title": "$container",
+      "gridPos": { "h": 20, "w": 24, "x": 0, "y": 1 },
+      "id": 2,
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{container=~\"$container\"} |~ \"(?i)$search\" |~ \"(?i)$level\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    },
+    {
+      "type": "row",
+      "title": "Scheduled Jobs",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 },
+      "collapsed": true,
+      "id": 3,
+      "panels": [
+        {
+          "type": "logs",
+          "title": "Job Logs",
+          "description": "Backups, alerts, scraper, availability (via journald)",
+          "gridPos": { "h": 12, "w": 24, "x": 0, "y": 22 },
+          "id": 4,
+          "datasource": { "type": "loki", "uid": "loki" },
+          "targets": [
+            {
+              "expr": "{unit=~\"$job\"}",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": false,
+            "enableLogDetails": true,
+            "sortOrder": "Descending",
+            "dedupStrategy": "none"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/services/grafana/dashboards/platform-health.json
+++ b/services/grafana/dashboards/platform-health.json
@@ -13,6 +13,11 @@
     "to": "now"
   },
   "tags": ["platform", "health"],
+  "links": [
+    { "title": "PostgreSQL", "url": "/d/postgres", "type": "link", "icon": "database" },
+    { "title": "Coupette", "url": "/d/coupette", "type": "link", "icon": "apps" },
+    { "title": "Logs", "url": "/d/logs", "type": "link", "icon": "document-info" }
+  ],
   "panels": [
     {
       "type": "row",
@@ -29,7 +34,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "count(container_last_seen{id!=\"/\"} > (time() - 120))",
+          "expr": "count(container_last_seen{name!=\"\"} > (time() - 120))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -40,8 +45,9 @@
             "mode": "absolute",
             "steps": [
               { "color": "red", "value": null },
-              { "color": "yellow", "value": 9 },
-              { "color": "green", "value": 10 }
+              { "color": "yellow", "value": 10 },
+              { "color": "green", "value": 11 },
+              { "color": "yellow", "value": 12 }
             ]
           },
           "unit": "none"
@@ -69,13 +75,7 @@
       "targets": [
         {
           "expr": "count(up == 1)",
-          "legendFormat": "up",
           "refId": "A"
-        },
-        {
-          "expr": "count(up)",
-          "legendFormat": "total",
-          "refId": "B"
         }
       ],
       "fieldConfig": {
@@ -84,7 +84,7 @@
             "mode": "absolute",
             "steps": [
               { "color": "red", "value": null },
-              { "color": "green", "value": 8 }
+              { "color": "green", "value": 9 }
             ]
           },
           "unit": "none"
@@ -97,7 +97,7 @@
         "textMode": "value",
         "reduceOptions": { "calcs": ["lastNotNull"] }
       },
-      "description": "Scrape targets reporting UP. Expand Internals to see details."
+      "description": "Scrape targets reporting UP (expected: 9). Expand Internals to see details."
     },
     {
       "type": "gauge",
@@ -229,39 +229,110 @@
       "id": 15
     },
     {
+      "type": "stat",
+      "title": "Unhealthy Containers",
+      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 8 },
+      "id": 19,
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "container_health_state{name!=\"\", health_status=\"unhealthy\"}",
+          "legendFormat": "{{ name }} UNHEALTHY",
+          "refId": "A"
+        },
+        {
+          "expr": "(time() - container_start_time_seconds{name!=\"\"}) < 300",
+          "legendFormat": "{{ name }} RESTARTED",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "All healthy",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "1": { "text": "UNHEALTHY", "color": "red" }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
       "type": "table",
       "title": "Container Details",
-      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 8 },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 10 },
       "id": 13,
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "time() - container_last_seen{id!=\"/\"}",
+          "expr": "rate(container_cpu_usage_seconds_total{name!=\"\", cpu=\"total\"}[5m]) * 100",
           "instant": true,
           "format": "table",
           "refId": "A"
+        },
+        {
+          "expr": "container_memory_usage_bytes{name!=\"\"}",
+          "instant": true,
+          "format": "table",
+          "refId": "B"
         }
       ],
       "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "name"
+          }
+        },
         {
           "id": "organize",
           "options": {
             "excludeByName": {
               "Time": true,
+              "Time 1": true,
+              "Time 2": true,
               "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
               "instance": true,
+              "instance 1": true,
+              "instance 2": true,
               "job": true,
+              "job 1": true,
+              "job 2": true,
               "id": true,
+              "id 1": true,
+              "id 2": true,
               "image": true,
+              "image 1": true,
+              "image 2": true,
               "cpu": true
             },
             "renameByName": {
               "name": "Container",
-              "Value": "Last Seen"
+              "Value #A": "CPU %",
+              "Value #B": "Memory"
             },
             "indexByName": {
               "name": 0,
-              "Value": 1
+              "Value #A": 1,
+              "Value #B": 2
             }
           }
         }
@@ -272,17 +343,39 @@
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "Last Seen" },
+            "matcher": { "id": "byName", "options": "CPU %" },
             "properties": [
-              { "id": "unit", "value": "s" },
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 },
               {
                 "id": "thresholds",
                 "value": {
                   "mode": "absolute",
                   "steps": [
                     { "color": "green", "value": null },
-                    { "color": "yellow", "value": 60 },
-                    { "color": "red", "value": 300 }
+                    { "color": "yellow", "value": 50 },
+                    { "color": "red", "value": 90 }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background" }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Memory" },
+            "properties": [
+              { "id": "unit", "value": "bytes" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 536870912 },
+                    { "color": "red", "value": 1073741824 }
                   ]
                 }
               },

--- a/services/grafana/dashboards/postgres.json
+++ b/services/grafana/dashboards/postgres.json
@@ -13,6 +13,11 @@
     "to": "now"
   },
   "tags": ["postgresql", "database"],
+  "links": [
+    { "title": "Platform Health", "url": "/d/platform-health", "type": "link", "icon": "dashboard" },
+    { "title": "Coupette", "url": "/d/coupette", "type": "link", "icon": "apps" },
+    { "title": "Logs", "url": "/d/logs", "type": "link", "icon": "document-info" }
+  ],
   "panels": [
     {
       "type": "row",

--- a/services/prometheus/prometheus.yml
+++ b/services/prometheus/prometheus.yml
@@ -21,6 +21,11 @@ scrape_configs:
     static_configs:
       - targets: ["caddy:2019"]
 
+  # Container metrics
+  - job_name: "cadvisor"
+    static_configs:
+      - targets: ["cadvisor:8080"]
+
   # App monitoring
   - job_name: "coupette-backend"
     static_configs:


### PR DESCRIPTION
## Summary

- **Standalone cAdvisor** — replaces broken embedded cAdvisor in Alloy. Separate container scraped by Prometheus. Per-container CPU and memory metrics now available.
- **Logs dashboard** (new) — unified log viewer with container dropdown, text search, and level filter. Scheduled Jobs section for systemd timer logs.
- **Container Details** reworked — shows CPU % and Memory per container (was "Last Seen" which was useless). Unhealthy/RESTARTED detection panel above the table.
- **Dashboard cross-links** — every dashboard links to the other three for quick navigation.
- **Container count thresholds** updated for cAdvisor (11 expected). Observability stat updated (9 scrape targets).

## Changes

- `docker-compose.yml` — added standalone cAdvisor service with `--docker_only` and disabled unnecessary metrics. Removed cAdvisor mounts from Alloy.
- `services/alloy/config.alloy` — removed embedded `prometheus.exporter.cadvisor` block
- `services/prometheus/prometheus.yml` — added `cadvisor:8080` scrape target
- `services/grafana/dashboards/logs.json` (new) — Container Logs + Scheduled Jobs with dropdown filters
- `services/grafana/dashboards/platform-health.json` — Unhealthy Containers panel, Container Details with CPU/Memory, Observability stat (single value), container count thresholds, dashboard links
- `services/grafana/dashboards/coupette.json` — dashboard links
- `services/grafana/dashboards/postgres.json` — dashboard links
- `Makefile` — added cadvisor to `make up`

## Deploy notes

After merge + CD:
1. cAdvisor container will start automatically
2. Verify per-container metrics:
   ```
   docker exec prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=container_cpu_usage_seconds_total{name!=""}' | python3 -c "import json,sys; data=json.load(sys.stdin)['data']['result']; print(f'{len(data)} series')"
   ```
3. Check Container Details table in Platform Health dashboard
4. Verify Logs dashboard loads with container dropdown
5. Clean up old test container if present: `docker rm -f cadvisor-test`