### PR TITLE
fix: cAdvisor v0.56.2 with host cgroup namespace (#113)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
         max-file: "3"
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.51.0
+    image: ghcr.io/google/cadvisor@sha256:5534ae91cbf3428998d60428d107cfdd97272d80658534ac6e54d8ce3b0c4d72
     container_name: cadvisor
     volumes:
       - /:/rootfs:ro
@@ -167,6 +167,8 @@ services:
       - "--disable_metrics=advtcp,cpu_topology,cpuset,hugetlb,memory_numa,process,referenced_memory,resctrl,sched,tcp,udp"
     networks:
       - internal
+    pid: host
+    cgroup: host
     read_only: true
     security_opt: [no-new-privileges:true]
     restart: unless-stopped

--- a/services/prometheus/prometheus.yml
+++ b/services/prometheus/prometheus.yml
@@ -21,7 +21,7 @@ scrape_configs:
     static_configs:
       - targets: ["caddy:2019"]
 
-  # Container metrics
+  # Container metrics (standalone cAdvisor)
   - job_name: "cadvisor"
     static_configs:
       - targets: ["cadvisor:8080"]


### PR DESCRIPTION
## Summary

cAdvisor v0.51.0 (and the embedded Alloy version) couldn't read per-container cgroup metrics on Debian 13 + Docker with containerd storage. Root cause: Docker moved from `image/overlayfs/layerdb/` to containerd-managed storage, and cAdvisor < v0.54.0 doesn't support this layout.

Fix: upgrade to cAdvisor v0.56.2 (`ghcr.io/google/cadvisor`, pinned by digest) with `pid: host` + `cgroup: host` to access host cgroup namespace.

## Changes

- `docker-compose.yml` — cAdvisor image upgraded from `gcr.io/cadvisor/cadvisor:v0.51.0` to `ghcr.io/google/cadvisor@sha256:5534...` (v0.56.2). Added `pid: host` and `cgroup: host`.
- `services/prometheus/prometheus.yml` — scrape target uses standalone cAdvisor at `cadvisor:8080`

## Deploy notes

After merge + CD:
1. Verify per-container metrics:
   ```
   docker exec prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=container_cpu_usage_seconds_total{name!=""}' | python3 -c "import json,sys; data=json.load(sys.stdin)['data']['result']; print(f'{len(data)} series')"
   ```
2. Check Container Details table in Platform Health dashboard
3. Clean up test container: `docker rm -f cadvisor-test`

Closes #113