### PR TITLE
fix: Uptime Kuma permissions + fail2ban lockout threshold

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -32,7 +32,7 @@ ufw_allowed_ports:
   - "443"
 
 # --- Fail2ban ---
-fail2ban_maxretry: 3
+fail2ban_maxretry: 5
 fail2ban_bantime: 3600
 fail2ban_findtime: 600
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       start_period: 30s
     security_opt: [no-new-privileges:true]
     cap_drop: [ALL]
+    cap_add: [CHOWN, DAC_OVERRIDE]
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Summary

- Add `CHOWN` and `DAC_OVERRIDE` capabilities to Uptime Kuma — `cap_drop: ALL` prevents the container from creating its `data/upload/` directory on fresh volumes
- Bump fail2ban `maxretry` from 3 to 5 — Ansible Phase 1 root SSH probe counts as a failed attempt, 3 runs in 10 minutes triggers a ban

## Changes

| File | Change |
|------|--------|
| `docker-compose.yml` | Add `cap_add: [CHOWN, DAC_OVERRIDE]` to uptime-kuma service |
| `ansible/group_vars/all/vars.yml` | `fail2ban_maxretry: 3` → `5` |

## Deploy notes

- **Uptime Kuma fix**: `docker compose up -d uptime-kuma` (or full `make restart`)
- **Fail2ban fix**: re-run Ansible playbook to apply new jail config