### PR TITLE
fix: allow deploy user to manage coupette systemd units

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
     environment: production
     steps:
-      - name: Deploy to web-01
+      - name: Deploy to VPS
         uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.SSH_DEPLOY_HOST }}

--- a/ansible/roles/infra/tasks/main.yml
+++ b/ansible/roles/infra/tasks/main.yml
@@ -22,12 +22,18 @@
       {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/systemctl daemon-reload
       {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/systemctl enable pg-backup.timer
       {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/systemctl enable disk-alert.timer
+      {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/systemctl enable --now coupette-scraper.timer
+      {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/systemctl enable --now coupette-availability.timer
       {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/systemctl start pg-backup.timer
       {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/systemctl start disk-alert.timer
       {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/systemd/system/pg-backup.service
       {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/systemd/system/pg-backup.timer
       {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/systemd/system/disk-alert.service
       {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/systemd/system/disk-alert.timer
+      {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/systemd/system/coupette-scraper.service
+      {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/systemd/system/coupette-scraper.timer
+      {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/systemd/system/coupette-availability.service
+      {{ deploy_user }} ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/systemd/system/coupette-availability.timer
     dest: "/etc/sudoers.d/{{ deploy_user }}"
     mode: "0440"
     validate: visudo -cf %s


### PR DESCRIPTION
## Summary

- Add coupette scraper and availability timer/service units to deploy user's scoped sudoers
- Rename deploy workflow step from `web-01` to `VPS` (host comes from secrets, label was stale)

## Changes

| File | Change |
|------|--------|
| `ansible/roles/infra/tasks/main.yml` | Add `tee` and `enable --now` sudoers entries for coupette-scraper and coupette-availability units |
| `.github/workflows/deploy.yml` | Rename step label `Deploy to web-01` → `Deploy to VPS` |

## Deploy notes

- Re-run Ansible playbook to push new sudoers config: `ansible-playbook site.yml --diff`
- Then re-deploy coupette — the `sudo tee` and `sudo systemctl` commands will work