### PR TITLE
feat: add coupette-redis service and remove unsafe-eval from CSP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,8 @@ services:
       retries: 3
       start_period: 5s
     restart: unless-stopped
+    mem_limit: 64m
+    read_only: true
     security_opt: [no-new-privileges:true]
     cap_drop: [ALL]
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,27 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  coupette-redis:
+    image: redis:7-bookworm
+    container_name: coupette-redis
+    command: redis-server --save "" --appendonly no --bind 0.0.0.0
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    cap_drop: [ALL]
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   # ============================================================================
   # Observability
   # ============================================================================

--- a/docs/APP_CONTRACT.md
+++ b/docs/APP_CONTRACT.md
@@ -61,6 +61,26 @@ DB_HOST=shared-postgres
 DB_PORT=5432
 ```
 
+## Redis
+
+A Redis 7 instance runs as `coupette-redis` on the `internal` network. Used by coupette for ephemeral key-value storage (e.g. OAuth state).
+
+| Property | Value |
+|----------|-------|
+| Container name | `coupette-redis` |
+| Image | `redis:7-bookworm` |
+| Internal port | 6379 |
+| Persistence | None — in-memory only, no RDB snapshots, no AOF |
+| Data lifetime | Keys expire per app-set TTL (e.g. 10 min for OAuth state) |
+
+All data is ephemeral. A container restart wipes all keys — apps must handle cache misses gracefully.
+
+### Connection from app repos
+
+```bash
+REDIS_URL=redis://coupette-redis:6379
+```
+
 ## Caddy Routing
 
 Caddy is the only internet-facing container. It routes traffic to app backends by container name on the `internal` network.
@@ -101,8 +121,9 @@ If an app renames its container, changes its port, or changes metric names, the 
 Infra services must be healthy before app deploys can succeed:
 
 1. `shared-postgres` must be healthy (app backends connect on startup)
-2. `caddy` must be running (routes traffic to app containers)
-3. `internal` network must exist (all containers attach to it)
+2. `coupette-redis` must be running (app backend connects on startup)
+3. `caddy` must be running (routes traffic to app containers)
+4. `internal` network must exist (all containers attach to it)
 
 If `make restart` is run on infra, app backends may lose postgres connectivity for ~10-30 seconds. App health checks should tolerate this.
 

--- a/scripts/deploy_infra.sh
+++ b/scripts/deploy_infra.sh
@@ -111,7 +111,8 @@ check_health_inspect() {
 }
 
 # Services with compose healthchecks — reuse via docker inspect
-check_health_inspect "postgres"   "shared-postgres"
+check_health_inspect "postgres"      "shared-postgres"
+check_health_inspect "coupette-redis"
 check_health_inspect "caddy"
 check_health_inspect "umami"
 check_health_inspect "uptime-kuma"

--- a/services/caddy/Caddyfile
+++ b/services/caddy/Caddyfile
@@ -48,7 +48,7 @@ www.coupette.club {
 
 coupette.club {
 	import security_headers
-	header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' https://analytics.victorpatrin.dev https://telegram.org; connect-src 'self' https://analytics.victorpatrin.dev; frame-src https://oauth.telegram.org; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'"
+	header Content-Security-Policy "default-src 'self'; script-src 'self' https://analytics.victorpatrin.dev https://telegram.org; connect-src 'self' https://analytics.victorpatrin.dev; frame-src https://oauth.telegram.org; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'"
 	encode zstd gzip
 	# API requests proxied to backend container
 	handle /api/* {


### PR DESCRIPTION
## Summary

- Add `coupette-redis` (Redis 7, Debian bookworm) to the infra compose stack for coupette OAuth state storage
- Remove `unsafe-eval` from `coupette.club` CSP — it was never needed (Umami loads via origin allowlist, not eval)
- Wire `coupette-redis` into the deploy health check

## Changes

- **`docker-compose.yml`** — new `coupette-redis` service: ephemeral in-memory only (`--save "" --appendonly no`), no published ports, full hardening (`read_only`, `mem_limit: 64m`, `cap_drop: [ALL]`, `security_opt`)
- **`docs/APP_CONTRACT.md`** — Redis section documenting container name, port, no-persistence guarantee, connection string; added to deploy dependencies
- **`scripts/deploy_infra.sh`** — added `coupette-redis` to post-deploy health checks
- **`services/caddy/Caddyfile`** — removed `unsafe-eval` from `coupette.club` `script-src`

## Deploy notes

`make restart` required on first deploy to start `coupette-redis`. Subsequent deploys via `deploy_infra.sh` as normal.