### PR TITLE
fix: start coupette-redis as redis user to bypass no-new-privileges restriction

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
     image: redis:7-bookworm
     container_name: coupette-redis
     command: redis-server --save "" --appendonly no --bind 0.0.0.0
+    user: redis
     networks:
       - internal
     healthcheck:


### PR DESCRIPTION
## Summary

- `coupette-redis` was crash-looping on the VPS with `failed switching to "redis": operation not permitted`
- Root cause: `security_opt: no-new-privileges:true` blocks `su-exec` in the Redis entrypoint from switching users — enforced strictly on Linux, silently ignored by Docker Desktop on Mac
- Fix: add `user: redis` to start the process directly as the `redis` user, bypassing the entrypoint user switch entirely

## Changes

- **`docker-compose.yml`** — add `user: redis` to `coupette-redis` service

## Deploy notes

```bash
docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d coupette-redis
```