### PR TITLE
fix: allow inline scripts in ccil.club CSP

### DIFF
--- a/services/caddy/Caddyfile
+++ b/services/caddy/Caddyfile
@@ -88,7 +88,7 @@ www.ccil.club {
 
 ccil.club {
 	import security_headers
-	header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:"
+	header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; worker-src 'self' blob:"
 	encode zstd gzip
 	reverse_proxy ccil:3000
 }


### PR DESCRIPTION
## Summary

- Add `'unsafe-inline'` to `script-src` in the ccil.club CSP header to fix blocked inline scripts

## Changes

- `services/caddy/Caddyfile` — added `'unsafe-inline'` to `script-src` directive for ccil.club

## Deploy notes

- `make reload-caddy` (no-downtime reload)